### PR TITLE
Fix missing enemy health gauges on PC

### DIFF
--- a/src/sysDolphin/dgxGraphics.cpp
+++ b/src/sysDolphin/dgxGraphics.cpp
@@ -1891,6 +1891,11 @@ void DGXGraphics::drawOneTri(immut Vector3f* vertices, immut Vector3f* normals, 
 		}
 		GXTexCoord2f32(texCoords[i].x, texCoords[i].y);
 	}
+#if defined(PIKI_PC_PORT)
+	// GX consumes the declared vertex count on hardware; the PC stream needs
+	// an explicit submission before the next primitive replaces its vertices.
+	GXEnd();
+#endif
 }
 
 /**


### PR DESCRIPTION
Damaged enemies can have no health gauge even when `LifeGauge` reaches its visible state. `DGXGraphics::drawOneTri` writes a triangle fan without calling `GXEnd`; on PC, the next `pc_gfx_begin` clears that pending vertex stream before `pc_gfx_end` can submit it.

Add the missing `GXEnd` under `PIKI_PC_PORT`, matching the explicit submission used by nearby rectangle helpers. This submits the gauge's colored sectors and border without changing its health, visibility, or animation logic. The hardware path is unchanged. Other callers of `drawOneTri` also receive the submission.

Validation:

- Confirmed the missing end call and stream-clearing behavior on upstream `main` at `18ce1303b488bc906721d1389143b65ace345695`.
- In a downstream Windows build, an isolated fixture placed a Bulbear near Olimar and held it at 50% health. Before the fix, its gauge was in Display state with ratio 0.5 and a valid screen projection, but absent from the captured framebuffer. With this change, the framebuffer showed the yellow half-circle and black border. This was a scripted rendering test, not a player-combat/death lifecycle test.
- Downstream production build and startup smoke passed after removing diagnostic instrumentation. No randomizer or diagnostic code is included here.
- `git diff --check` passes. Compiling this translation unit in a fresh upstream Windows/MinGW CMake build is blocked by existing missing `HWND`/`HINSTANCE` and OpenGL types; the unmodified upstream baseline fails the same check. A clean upstream build/runtime test is therefore still pending.
