### PR TITLE
Repair public Linux CI and separate private matching builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,12 @@
-name: Build
+name: Legacy matching build
 
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:
+    # Requires access to the private toolchain image and its original game files.
+    # Public native-port validation runs in linux.yml on every push/PR.
     container: ghcr.io/projectpiki/build:main
 
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,9 +30,8 @@ jobs:
           path: nectar-linux.tar.gz
 
   smoke-clean-distro:
-    # Reproduce lo que verá otro equipo: una distro limpia donde SOLO se
-    # instala el driver OpenGL (libgl1). Ni SDL2 ni nada más: el paquete
-    # debe ser autocontenido.
+    # Install the graphics runtime documented in packaging/linux/README.txt.
+    # SDL2 and the non-driver runtime must come from the package itself.
     needs: build
     runs-on: ubuntu-latest
     container: debian:12
@@ -42,8 +41,8 @@ jobs:
           name: nectar-linux
       - name: Extract package with executable permissions
         run: tar -xzf nectar-linux.tar.gz
-      - name: Install only the documented requirement (OpenGL driver)
-        run: apt-get update && apt-get install -y --no-install-recommends libgl1 libopengl0
+      - name: Install documented graphics runtime
+        run: apt-get update && apt-get install -y --no-install-recommends libgl1 libopengl0 libglvnd0 libgbm1 libdrm2 libgl1-mesa-dri
       - name: Standalone package runs on clean Debian 12
         run: |
           cd nectar-linux

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,11 +21,13 @@ jobs:
             echo 'Proprietary game data found in repository'
             exit 1
           fi
+      - name: Archive package with executable permissions
+        run: tar -czf nectar-linux.tar.gz -C packaging/linux/out nectar-linux
       - name: Upload standalone package
         uses: actions/upload-artifact@v4
         with:
           name: nectar-linux
-          path: packaging/linux/out/nectar-linux
+          path: nectar-linux.tar.gz
 
   smoke-clean-distro:
     # Reproduce lo que verá otro equipo: una distro limpia donde SOLO se
@@ -38,7 +40,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: nectar-linux
-          path: nectar-linux
+      - name: Extract package with executable permissions
+        run: tar -xzf nectar-linux.tar.gz
       - name: Install only the documented requirement (OpenGL driver)
         run: apt-get update && apt-get install -y --no-install-recommends libgl1 libopengl0
       - name: Standalone package runs on clean Debian 12

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: nectar-linux
+          path: nectar-linux
       - name: Install only the documented requirement (OpenGL driver)
         run: apt-get update && apt-get install -y --no-install-recommends libgl1 libopengl0
       - name: Standalone package runs on clean Debian 12

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,7 +49,6 @@ jobs:
           cd nectar-linux
           chmod +x nectar nectar-launcher
           ./nectar-launcher --help
-          if LD_LIBRARY_PATH=lib ldd nectar.real | grep 'not found'; then
-            echo 'Unresolved dependencies in the standalone package'
-            exit 1
-          fi
+          # Resolve with the packaged loader, as the launch wrappers do. Do not
+          # inject the bundled libc into the clean distro's own ldd process.
+          ./lib/ld-linux-x86-64.so.2 --library-path ./lib --list ./nectar.real

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,5 +655,6 @@ message(STATUS "")
 if(PIKMIN_NATIVE_JAUDIO)
     add_test(NAME pc_jaudio_integration_test COMMAND pikmin_pc --audio-self-test)
     set_tests_properties(pc_jaudio_integration_test PROPERTIES
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" TIMEOUT 30)
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" TIMEOUT 30
+        SKIP_RETURN_CODE 77 LABELS "game-assets")
 endif()

--- a/include/Slime.h
+++ b/include/Slime.h
@@ -311,7 +311,7 @@ public:
 						f32 x = weightPos.x - mSlime->mSlimeCreatures[k]->mSRT.t.x;
 						f32 y = weightPos.y - mSlime->mSlimeCreatures[k]->mSRT.t.y;
 						f32 z = weightPos.z - mSlime->mSlimeCreatures[k]->mSRT.t.z;
-						score += mSlime->mAppearanceScale / std::sqrtf(SQUARE(x) + SQUARE(y) + SQUARE(z));
+						score += mSlime->mAppearanceScale / sqrtf(SQUARE(x) + SQUARE(y) + SQUARE(z));
 					}
 
 					// closer to other stick slimes = higher score

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -63,7 +63,7 @@ public:
 	void input(immut Vector3f& other) { set(other.x, other.y, other.z); }
 	void output(Vector3f& outVec) immut { outVec.set(x, y, z); }
 
-	f32 length() immut { return std::sqrtf(SQUARE(x) + SQUARE(y) + SQUARE(z)); }
+	f32 length() immut { return sqrtf(SQUARE(x) + SQUARE(y) + SQUARE(z)); }
 	f32 squaredLength() immut { return SQUARE(x) + SQUARE(y) + SQUARE(z); }
 
 	// TODO: implementions are guessed, a manual check if accurate required

--- a/include/nlib/Math.h
+++ b/include/nlib/Math.h
@@ -83,7 +83,7 @@ struct NMathF {
 	}
 
 	static inline f32 interpolate(f32 x, f32 y, f32 t) { return x * (1.0f - t) + y * t; }
-	static inline f32 length(f32 x, f32 y) { return std::sqrtf(SQUARE(x) + SQUARE(y)); }
+	static inline f32 length(f32 x, f32 y) { return sqrtf(SQUARE(x) + SQUARE(y)); }
 
 	static inline bool equals(f32 x, f32 y) { return NMathF::isZero(x - y); }
 	static inline bool isPositive(f32 x) { return x >= error; }
@@ -133,9 +133,9 @@ struct NMathF {
 	static inline f32 rangeRandom(f32 min, f32 max) { return (max - min) * NSystem::random() + min; }
 	static inline bool occurred(f32 chance) { return NSystem::random() < chance; }
 	static inline f32 rateRandom(f32 min, f32 range) { return min * (2.0f * (NSystem::random() - 0.5f)) * range + min; }
-	static inline f32 sqrt(f32 x) { return std::sqrtf(x); }
+	static inline f32 sqrt(f32 x) { return sqrtf(x); }
 	static inline int quotient(f32 num, f32 denom) { return num / denom; }
-	static inline f32 acos(f32 x) { return NMathF::atan2(std::sqrtf(1.0f - SQUARE(x)), x); }
+	static inline f32 acos(f32 x) { return NMathF::atan2(sqrtf(1.0f - SQUARE(x)), x); }
 };
 
 struct NMathI {

--- a/pc_port/audio/jaudio_integration_test.cpp
+++ b/pc_port/audio/jaudio_integration_test.cpp
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <algorithm>
+#include <filesystem>
 
 namespace {
 u64 frames = 0, nonzero = 0;
@@ -36,6 +37,12 @@ void pump(u32 milliseconds)
 }
 int pc_jaudio_integration_test()
 {
+    // Public source-only builds cannot exercise proprietary audio content.
+    // Keep the test enabled for developer checkouts with extracted assets.
+    if (!std::filesystem::is_directory("assets/dataDir/SndData")) {
+        std::puts("[jaudio-test] SKIP: extracted assets/dataDir/SndData is required");
+        return 77;
+    }
     SDL_setenv("SDL_AUDIODRIVER", std::getenv("PIKMIN_AUDIO_TEST_NO_DEVICE") ? "unavailable-test-driver" : "dummy", 1);
     // Native pointer graphs are larger than the console's packed bank image.
     constexpr u32 heapSize = 0x80000;

--- a/pc_port/pc_types.h
+++ b/pc_port/pc_types.h
@@ -173,7 +173,7 @@ static unsigned int __pc_rlwinm(unsigned int value, unsigned int shift, unsigned
 /* ──────────────────────────────────────────────
  *  Single-precision C math under std:: (MinGW)
  *
- *  The decompiled code calls sqrtf, fmodf and friends in 25 files.
+ *  The decompiled code calls std::sqrtf, std::fmodf and friends in 25 files.
  *  Those names come from <math.h> and the C++ standard never required them in
  *  namespace std; glibc's headers add them anyway, MinGW's do not. Rather than
  *  edit decompiled sources, pull the global versions into std here. This

--- a/pc_port/pc_types.h
+++ b/pc_port/pc_types.h
@@ -173,7 +173,7 @@ static unsigned int __pc_rlwinm(unsigned int value, unsigned int shift, unsigned
 /* ──────────────────────────────────────────────
  *  Single-precision C math under std:: (MinGW)
  *
- *  The decompiled code calls std::sqrtf, std::fmodf and friends in 25 files.
+ *  The decompiled code calls sqrtf, fmodf and friends in 25 files.
  *  Those names come from <math.h> and the C++ standard never required them in
  *  namespace std; glibc's headers add them anyway, MinGW's do not. Rather than
  *  edit decompiled sources, pull the global versions into std here. This

--- a/src/jaudio/ja_calc.c
+++ b/src/jaudio/ja_calc.c
@@ -11,7 +11,7 @@ static f32 SINTABLE[SINTABLE_LENGTH];
  */
 f32 sqrtf2(f32 x)
 {
-	return std::sqrtf(x);
+	return sqrtf(x);
 }
 
 /**

--- a/src/plugPikiColin/cinePlayer.cpp
+++ b/src/plugPikiColin/cinePlayer.cpp
@@ -976,7 +976,7 @@ void ActorInstance::refresh(immut Matrix4f& mtx, Graphics& gfx, f32* p3)
 		check1 = true;
 		d      = &mAnimator.mAnimationCounter;
 	} else if (p3 && mActiveActor->mModel->mCurrentAnimation->mData->mTotalFrameCount) {
-		c = std::fmodf(*p3, mActiveActor->mModel->mCurrentAnimation->mData->mTotalFrameCount);
+		c = fmodf(*p3, mActiveActor->mModel->mCurrentAnimation->mData->mTotalFrameCount);
 		d = &c;
 	}
 

--- a/src/plugPikiKando/aiCrowd.cpp
+++ b/src/plugPikiKando/aiCrowd.cpp
@@ -318,7 +318,7 @@ int ActCrowd::exec()
 	}
 
 	Vector3f plateDir = platePos - mPiki->mSRT.t;
-	f32 plateDist2D   = std::sqrtf(plateDir.x * plateDir.x + plateDir.z * plateDir.z);
+	f32 plateDist2D   = sqrtf(plateDir.x * plateDir.x + plateDir.z * plateDir.z);
 	plateDir.normalise();
 
 	if (plateDist2D < 60.0f && mPiki->mNavi->mIsCStickNeutral && mState != STATE_Sort) {

--- a/src/plugPikiKando/aiStone.cpp
+++ b/src/plugPikiKando/aiStone.cpp
@@ -104,7 +104,7 @@ int ActStone::exeApproach()
 	}
 
 	Vector3f direction = mCurrPebble->mPosition - mPiki->mSRT.t;
-	f32 dist2D         = std::sqrtf(direction.x * direction.x + direction.z * direction.z);
+	f32 dist2D         = sqrtf(direction.x * direction.x + direction.z * direction.z);
 	f32 unused         = direction.normalise();
 
 	if (dist2D <= 20.0f) {
@@ -135,7 +135,7 @@ int ActStone::exeAdjust()
 	}
 
 	Vector3f direction = mCurrPebble->mPosition - mPiki->mSRT.t;
-	f32 dist2D         = std::sqrtf(direction.x * direction.x + direction.z * direction.z);
+	f32 dist2D         = sqrtf(direction.x * direction.x + direction.z * direction.z);
 	f32 unused         = direction.normalise();
 
 	if (dist2D < 8.0f) {

--- a/src/plugPikiKando/aiWeed.cpp
+++ b/src/plugPikiKando/aiWeed.cpp
@@ -97,7 +97,7 @@ int ActWeed::exeApproach()
 	}
 
 	Vector3f direction = mCurrGrass->mPosition - mPiki->mSRT.t;
-	f32 dist2D         = std::sqrtf(direction.x * direction.x + direction.z * direction.z);
+	f32 dist2D         = sqrtf(direction.x * direction.x + direction.z * direction.z);
 	f32 unused         = direction.normalise();
 
 	if (dist2D <= 20.0f) {
@@ -133,7 +133,7 @@ int ActWeed::exeAdjust()
 	}
 
 	Vector3f direction = mCurrGrass->mPosition - mPiki->mSRT.t;
-	f32 dist2D         = std::sqrtf(direction.x * direction.x + direction.z * direction.z);
+	f32 dist2D         = sqrtf(direction.x * direction.x + direction.z * direction.z);
 	f32 unused         = direction.normalise();
 
 	if (dist2D < 4.0f) {

--- a/src/plugPikiKando/collInfo.cpp
+++ b/src/plugPikiKando/collInfo.cpp
@@ -56,19 +56,19 @@ f32 Cylinder::get2dDist(immut Vector3f& point) immut
 	if (projectionRatio < 0.0f) {
 		// Before cylinder start - get 2D distance to start point
 		Vector3f startToPoint = mStartPoint - point;
-		return std::sqrtf(startToPoint.x * startToPoint.x + startToPoint.z * startToPoint.z);
+		return sqrtf(startToPoint.x * startToPoint.x + startToPoint.z * startToPoint.z);
 	}
 
 	if (projectionRatio > 1.0f) {
 		// Past cylinder end - get 2D distance to end point
 		Vector3f endToPoint = mEndPoint - point;
-		return std::sqrtf(endToPoint.x * endToPoint.x + endToPoint.z * endToPoint.z);
+		return sqrtf(endToPoint.x * endToPoint.x + endToPoint.z * endToPoint.z);
 	}
 
 	// On cylinder body - get distance to projected point
 	Vector3f projectedPoint = (cylinderDir * projectionRatio) + mStartPoint;
 	projectedPoint          = projectedPoint - point;
-	return std::sqrtf(projectedPoint.x * projectedPoint.x + projectedPoint.z * projectedPoint.z);
+	return sqrtf(projectedPoint.x * projectedPoint.x + projectedPoint.z * projectedPoint.z);
 }
 
 /**

--- a/src/plugPikiKando/creature.cpp
+++ b/src/plugPikiKando/creature.cpp
@@ -1239,7 +1239,7 @@ f32 qdist2(Creature* c1, Creature* c2)
 {
 	f32 xDiff = c1->mSRT.t.x - c2->mSRT.t.x;
 	f32 zDiff = c1->mSRT.t.z - c2->mSRT.t.z;
-	return std::sqrtf(SQUARE(xDiff) + SQUARE(zDiff));
+	return sqrtf(SQUARE(xDiff) + SQUARE(zDiff));
 }
 
 /**

--- a/src/plugPikiKando/formationMgr.cpp
+++ b/src/plugPikiKando/formationMgr.cpp
@@ -401,7 +401,7 @@ void PyramidArranger::arrange(FormationMgr* mgr)
 f32 PyramidArranger::getLength(FormationMgr* mgr)
 {
 	int count = mgr->mCount; // load bearing temp. try it.
-	return (-1.0f + std::sqrtf(count * 8.0f + 1.0f)) / 2.0f * 26.0f;
+	return (-1.0f + sqrtf(count * 8.0f + 1.0f)) / 2.0f * 26.0f;
 }
 
 /**

--- a/src/plugPikiKando/navi.cpp
+++ b/src/plugPikiKando/navi.cpp
@@ -1338,7 +1338,7 @@ void Navi::releasePikis()
 	for (colorIdx1 = 0; colorIdx1 < PikiColorCount + 1; colorIdx1++) {
 		if (colorCounts[colorIdx1] > 0) {
 			colorCoMs[colorIdx1].multiply(1.0f / colorCounts[colorIdx1]);
-			colorSizes[colorIdx1] = (2.5f * pikiList[0]->getSize()) * std::sqrtf(colorCounts[colorIdx1]);
+			colorSizes[colorIdx1] = (2.5f * pikiList[0]->getSize()) * sqrtf(colorCounts[colorIdx1]);
 		}
 	}
 
@@ -1472,14 +1472,14 @@ bool Navi::procActionButton()
 #endif
 				{
 					Vector3f pelShipSep = pellet->mSRT.t - ship->getGoalPos();
-					f32 distFromShip    = std::sqrtf(pelShipSep.x * pelShipSep.x + pelShipSep.z * pelShipSep.z);
+					f32 distFromShip    = sqrtf(pelShipSep.x * pelShipSep.x + pelShipSep.z * pelShipSep.z);
 					if (distFromShip < 30.0f && pellet->mCarrierCounter != 0) {
 						continue;
 					}
 				}
 
 				Vector3f pelNaviSep = pellet->mSRT.t - mSRT.t;
-				f32 distFromNavi    = std::sqrtf(pelNaviSep.x * pelNaviSep.x + pelNaviSep.z * pelNaviSep.z) - pellet->getBottomRadius();
+				f32 distFromNavi    = sqrtf(pelNaviSep.x * pelNaviSep.x + pelNaviSep.z * pelNaviSep.z) - pellet->getBottomRadius();
 				if (distFromNavi <= 20.0f) {
 					int idx = PelletMgr::getUfoIndexFromID(pellet->mConfig->mModelId.mId);
 					if (idx == -1) {
@@ -1500,7 +1500,7 @@ bool Navi::procActionButton()
 		UfoItem* ship = itemMgr->getUfo();
 		if (ship) {
 			Vector3f naviShipSep = ship->mSRT.t - mSRT.t;
-			f32 naviShipDist     = std::sqrtf(naviShipSep.x * naviShipSep.x + naviShipSep.z * naviShipSep.z);
+			f32 naviShipDist     = sqrtf(naviShipSep.x * naviShipSep.x + naviShipSep.z * naviShipSep.z);
 			if (naviShipDist <= 50.0f) {
 				mStateMachine->transit(this, NAVISTATE_UfoAccess);
 				return true;
@@ -1531,7 +1531,7 @@ bool Navi::procActionButton()
 			}
 
 			Vector3f sproutNaviSep = sprout->mSRT.t - mSRT.t;
-			f32 sproutDist         = std::sqrtf(sproutNaviSep.x * sproutNaviSep.x + sproutNaviSep.z * sproutNaviSep.z);
+			f32 sproutDist         = sqrtf(sproutNaviSep.x * sproutNaviSep.x + sproutNaviSep.z * sproutNaviSep.z);
 			f32 heightDiff         = absF(sproutNaviSep.y);
 			if (sprout->canPullout() && sproutDist < minDist && heightDiff < 25.0f) {
 				minDist       = sproutDist;
@@ -2906,7 +2906,7 @@ void Navi::updateLook()
 	if (mLookAtPosPtr) {
 		Vector3f lookDelta = *mLookAtPosPtr - mSRT.t;
 		targetYaw          = atan2f(lookDelta.x, lookDelta.z);
-		f32 horizDist      = std::sqrtf(lookDelta.x * lookDelta.x + lookDelta.z * lookDelta.z);
+		f32 horizDist      = sqrtf(lookDelta.x * lookDelta.x + lookDelta.z * lookDelta.z);
 		targetPitch        = atan2f(lookDelta.y, horizDist);
 	} else {
 		f32 returnFactor  = 0.2f;

--- a/src/plugPikiKando/naviDemoState.cpp
+++ b/src/plugPikiKando/naviDemoState.cpp
@@ -63,7 +63,7 @@ void NaviDemoSunsetState::GoState::exec(NaviDemoSunsetState* state)
 	}
 
 	Vector3f diff = state->mGoalPos - state->mNavi->mSRT.t;
-	f32 dist      = std::sqrtf(diff.x * diff.x + diff.z * diff.z);
+	f32 dist      = sqrtf(diff.x * diff.x + diff.z * diff.z);
 	f32 nrm       = diff.normalise() / state->mGoalDistance;
 
 	if (nrm > 0.7f && nrm < 0.71f && gsys->getRand(1.0f) >= 0.9999f) {

--- a/src/plugPikiKando/naviState.cpp
+++ b/src/plugPikiKando/naviState.cpp
@@ -410,7 +410,7 @@ void NaviBuryState::exec(Navi* navi)
 	Vector3f stickInput(navi->mKontroller->getMainStickX(), 0.0f, navi->mKontroller->getMainStickY());
 	navi->reviseController(stickInput);
 
-	f32 stickMag = std::sqrtf(stickInput.x * stickInput.x + stickInput.z * stickInput.z);
+	f32 stickMag = sqrtf(stickInput.x * stickInput.x + stickInput.z * stickInput.z);
 
 	switch (mBuryState) {
 	case 0:

--- a/src/plugPikiKando/viewPiki.cpp
+++ b/src/plugPikiKando/viewPiki.cpp
@@ -359,7 +359,7 @@ void Piki::updateLook()
 	if (mLookatPosPtr) {
 		Vector3f targetOffset = *mLookatPosPtr - mSRT.t;
 		horizontalAngle       = atan2f(targetOffset.x, targetOffset.z);
-		horizontalDistance    = std::sqrtf(targetOffset.x * targetOffset.x + targetOffset.z * targetOffset.z);
+		horizontalDistance    = sqrtf(targetOffset.x * targetOffset.x + targetOffset.z * targetOffset.z);
 		verticalAngle         = atan2f(targetOffset.y, horizontalDistance);
 	} else {
 		rotationSpeed       = 0.2f;

--- a/src/plugPikiKando/weedsItem.cpp
+++ b/src/plugPikiKando/weedsItem.cpp
@@ -87,7 +87,7 @@ void RockGen::resolve()
 				Vector3f& pos2 = mPebbles[k].mPosition;
 
 				Vector3f separation = pos - pos2;
-				f32 distance        = std::sqrtf(separation.x * separation.x + separation.z * separation.z);
+				f32 distance        = sqrtf(separation.x * separation.x + separation.z * separation.z);
 				separation.normalise();
 				if (distance < 30.0f) {
 					separation = separation * 15.0f;
@@ -114,7 +114,7 @@ void GrassGen::resolve()
 			for (int k = j + 1; k < max; k++) {
 				Vector3f* pos2 = &mGrass[k].mPosition;
 				Vector3f diff  = *pos - *pos2;
-				f32 len        = std::sqrtf(diff.x * diff.x + diff.z * diff.z);
+				f32 len        = sqrtf(diff.x * diff.x + diff.z * diff.z);
 				diff.normalise();
 				if (len < 30.0f) {
 					diff  = diff * 15.0f;

--- a/src/plugPikiKando/workObject.cpp
+++ b/src/plugPikiKando/workObject.cpp
@@ -830,7 +830,7 @@ void HinderRock::update()
 
 		mIsMoving = true;
 		mVelocity = mDestinationPosition - mSRT.t;
-		if (std::sqrtf(mVelocity.x * mVelocity.x + mVelocity.z * mVelocity.z) < 4.0f) {
+		if (sqrtf(mVelocity.x * mVelocity.x + mVelocity.z * mVelocity.z) < 4.0f) {
 			mSRT.t = mDestinationPosition;
 			mState = 2;
 			mWayPoint->setFlag(true);

--- a/src/plugPikiNishimura/SlimeBody.cpp
+++ b/src/plugPikiNishimura/SlimeBody.cpp
@@ -158,7 +158,7 @@ f32 SlimeBody::calcVertexScore(immut Vector3f* vertex, Vector3f* creatureNormals
 		creatureNormals[i].y = (vertex->y - mRelativeVelocities[i].y) * mSlime->mBodyThickness;
 		creatureNormals[i].z = vertex->z - mRelativeVelocities[i].z;
 		creatureScores[i]    = mSlime->mAppearanceScale
-		                  / std::sqrtf(SQUARE(creatureNormals[i].x) + SQUARE(creatureNormals[i].y) + SQUARE(creatureNormals[i].z));
+		                  / sqrtf(SQUARE(creatureNormals[i].x) + SQUARE(creatureNormals[i].y) + SQUARE(creatureNormals[i].z));
 		score += creatureScores[i];
 	}
 	return score;

--- a/src/plugPikiNishimura/nscalculation.cpp
+++ b/src/plugPikiNishimura/nscalculation.cpp
@@ -115,7 +115,7 @@ void NsCalculation::calcJointPos(const Vector3f& topPosition, const Vector3f& bo
 			calcOuterPro(botToTop, adjBotToTop, middleJointPos);
 			f32 midJointSqr = SQUARE(middleJointPos.x) + SQUARE(middleJointPos.y) + SQUARE(middleJointPos.z);
 			if (midJointSqr != 0.0f) {
-				factor                = std::sqrtf(adjSqr / midJointSqr);
+				factor                = sqrtf(adjSqr / midJointSqr);
 				bottomJointPosition.x = factor * middleJointPos.x + adjTop.x;
 				bottomJointPosition.y = factor * middleJointPos.y + adjTop.y;
 				bottomJointPosition.z = factor * middleJointPos.z + adjTop.z;
@@ -124,8 +124,8 @@ void NsCalculation::calcJointPos(const Vector3f& topPosition, const Vector3f& bo
 		}
 	}
 
-	topToMiddleDistance    = std::sqrtf(topMidSqr);
-	middleToBottomDistance = std::sqrtf(midBotSqr);
+	topToMiddleDistance    = sqrtf(topMidSqr);
+	middleToBottomDistance = sqrtf(midBotSqr);
 
 	f32 rootVal           = topToMiddleDistance / (topToMiddleDistance + middleToBottomDistance);
 	bottomJointPosition.x = rootVal * botToTop.x + topPosition.x;

--- a/src/plugPikiOgawa/ogRader.cpp
+++ b/src/plugPikiOgawa/ogRader.cpp
@@ -558,7 +558,7 @@ void zen::ogRaderMgr::AreaScroll(f32* p1, f32* p2, f32 p3, f32 p4)
 	f32 z1 = b + z - d;
 	PRINT("scroll(%7.2f, %7.2f)  orima(%7.2f, %7.2f)  area(%7.2f, %7.2f)\n", p3, p4, mOlimarWorldPos.x, mOlimarWorldPos.z, mMapAreaCenterX,
 	      mMapAreaCenterZ);
-	f32 dist = std::sqrtf(SQUARE(x1) + SQUARE(z1));
+	f32 dist = sqrtf(SQUARE(x1) + SQUARE(z1));
 	if (dist < mMapAreaRadius) {
 		*p1 = a;
 		*p2 = b;

--- a/src/plugPikiYamashita/TAIAmove.cpp
+++ b/src/plugPikiYamashita/TAIAmove.cpp
@@ -980,7 +980,7 @@ bool TAIAflyingToGoal::act(Teki& teki)
 		f32 x = teki.mTargetPosition.x - teki.getPosition().x;
 		f32 z = teki.mTargetPosition.z - teki.getPosition().z;
 
-		f32 dist2 = std::sqrtf(x * x + z * z);
+		f32 dist2 = sqrtf(x * x + z * z);
 		if (dist2 <= teki.getParameterF(TPF_WalkVelocity)) {
 			return goal(teki);
 		}

--- a/src/plugPikiYamashita/particleGenerator.cpp
+++ b/src/plugPikiYamashita/particleGenerator.cpp
@@ -402,7 +402,7 @@ void zen::particleGenerator::pmSetDDF(u8* data)
 		if (len == 0.0f) {
 			pmGetArbitUnitVec(mVortexCenter);
 		} else {
-			len = std::sqrtf(len);
+			len = sqrtf(len);
 			mVortexCenter.x /= len;
 			mVortexCenter.y /= len;
 			mVortexCenter.z /= len;
@@ -414,7 +414,7 @@ void zen::particleGenerator::pmSetDDF(u8* data)
 		if (len == 0.0f) {
 			pmGetArbitUnitVec(mLineFieldAxis);
 		} else {
-			len = std::sqrtf(len);
+			len = sqrtf(len);
 			mLineFieldAxis.x /= len;
 			mLineFieldAxis.y /= len;
 			mLineFieldAxis.z /= len;
@@ -518,7 +518,7 @@ void zen::particleGenerator::PtclsGen(zen::particleMdl* ptcl)
 	if (scale == 0.0f) {
 		pmGetArbitUnitVec(emitDir);
 	} else {
-		scale = std::sqrtf(scale);
+		scale = sqrtf(scale);
 		emitDir.x /= scale;
 		emitDir.y /= scale;
 		emitDir.z /= scale;
@@ -603,7 +603,7 @@ void zen::particleGenerator::PtclsGen(zen::particleMdl* ptcl)
 				ptcl->mAge      = 0;
 				ptcl->mAgeTimer = 0.0f;
 			} else {
-				scale = std::sqrtf(scale);
+				scale = sqrtf(scale);
 				ptclVel.x /= scale;
 				ptclVel.y /= scale;
 				ptclVel.z /= scale;
@@ -646,7 +646,7 @@ void zen::particleGenerator::PtclsGen(zen::particleMdl* ptcl)
 			ptcl->mAgeTimer = 0.0f;
 
 		} else {
-			scale = std::sqrtf(scale);
+			scale = sqrtf(scale);
 			ptclVel.x /= scale;
 			ptclVel.y /= scale;
 			ptclVel.z /= scale;
@@ -860,7 +860,7 @@ void zen::particleGenerator::UpdatePtclsStatus(f32 timeStep)
 				f32 speed
 				    = ptcl->mVelocity.x * ptcl->mVelocity.x + ptcl->mVelocity.y * ptcl->mVelocity.y + ptcl->mVelocity.z * ptcl->mVelocity.z;
 				if (speed > mMaxVel * mMaxVel) {
-					f32 norm = std::sqrtf(speed);
+					f32 norm = sqrtf(speed);
 					ptcl->mVelocity.x *= mMaxVel / norm;
 					ptcl->mVelocity.y *= mMaxVel / norm;
 					ptcl->mVelocity.z *= mMaxVel / norm;

--- a/src/sysCommon/graphics.cpp
+++ b/src/sysCommon/graphics.cpp
@@ -63,7 +63,7 @@ void PVWPolygonColourInfo::animate(f32* data, Colour& col)
 	}
 
 	if (data) {
-		mCurrentFrame = std::fmodf(data[0], mTotalFrameCount);
+		mCurrentFrame = fmodf(data[0], mTotalFrameCount);
 	} else {
 		// If no new data is provided, increment the current frame
 #if defined(PIKI_PC_PORT)
@@ -404,7 +404,7 @@ void PVWTextureData::animate(f32* framePtr, Matrix4f& mtx)
 		}
 	} else {
 		if (framePtr) {
-			mCurrentFrame = std::fmodf(*framePtr, (f32)mTotalFrameCount);
+			mCurrentFrame = fmodf(*framePtr, (f32)mTotalFrameCount);
 		} else {
 #if defined(PIKI_PC_PORT)
 			if (pc_render_is_authoritative()) {
@@ -536,7 +536,7 @@ void PVWTevColReg::animate(f32* framePtr, ShortColour& color)
 	}
 
 	if (framePtr) {
-		mCurrentAnimFrame = std::fmodf(*framePtr, mAnimFrameCount);
+		mCurrentAnimFrame = fmodf(*framePtr, mAnimFrameCount);
 	} else {
 #if defined(PIKI_PC_PORT)
 		if (pc_render_is_authoritative()) {

--- a/src/sysCommon/sysMath.cpp
+++ b/src/sysCommon/sysMath.cpp
@@ -237,7 +237,7 @@ void Quat::fromMat3f(immut Matrix3f& mtx)
 	switch (type) {
 	case 0:
 	{
-		s   = std::sqrtf(a);
+		s   = sqrtf(a);
 		t   = 0.25f / s;
 		v.x = t * (mtx.mMtx[2][1] - mtx.mMtx[1][2]);
 		v.y = t * (mtx.mMtx[0][2] - mtx.mMtx[2][0]);
@@ -246,7 +246,7 @@ void Quat::fromMat3f(immut Matrix3f& mtx)
 	}
 	case 1:
 	{
-		v.x = std::sqrtf(b);
+		v.x = sqrtf(b);
 		t   = 0.25f / v.x;
 		s   = t * (mtx.mMtx[2][1] - mtx.mMtx[1][2]);
 		v.y = t * (mtx.mMtx[0][1] + mtx.mMtx[1][0]);
@@ -255,7 +255,7 @@ void Quat::fromMat3f(immut Matrix3f& mtx)
 	}
 	case 2:
 	{
-		v.y = std::sqrtf(c);
+		v.y = sqrtf(c);
 		t   = 0.25f / v.y;
 		s   = t * (mtx.mMtx[0][2] - mtx.mMtx[2][0]);
 		v.z = t * (mtx.mMtx[1][2] + mtx.mMtx[2][1]);
@@ -264,7 +264,7 @@ void Quat::fromMat3f(immut Matrix3f& mtx)
 	}
 	case 3:
 	{
-		v.z = std::sqrtf(d);
+		v.z = sqrtf(d);
 		t   = 0.25f / v.z;
 		s   = t * (mtx.mMtx[1][0] - mtx.mMtx[0][1]);
 		v.x = t * (mtx.mMtx[2][0] + mtx.mMtx[0][2]);
@@ -280,7 +280,7 @@ void Quat::fromMat3f(immut Matrix3f& mtx)
 		v.z = -v.z;
 	}
 
-	t = 1.0f / std::sqrtf(SQUARE(s) + SQUARE(v.x) + SQUARE(v.y) + SQUARE(v.z));
+	t = 1.0f / sqrtf(SQUARE(s) + SQUARE(v.x) + SQUARE(v.y) + SQUARE(v.z));
 
 	s *= t;
 	v.x *= t;
@@ -332,7 +332,7 @@ void Quat::multiplyTo(immut Quat& other, Quat& outQuat)
  */
 void Quat::normalise()
 {
-	f32 factor = 1.0f / std::sqrtf(v.x * v.x + v.y * v.y + v.z * v.z + s * s);
+	f32 factor = 1.0f / sqrtf(v.x * v.x + v.y * v.y + v.z * v.z + s * s);
 	v.x *= factor;
 	v.y *= factor;
 	v.z *= factor;
@@ -766,7 +766,7 @@ f32 distanceTriRect(KTri& tri, KRect& rect, f32* barycentricU, f32* barycentricV
 		return 0.0f;
 	}
 
-	return std::sqrtf(sqrDist);
+	return sqrtf(sqrDist);
 }
 
 /**


### PR DESCRIPTION
Public CI fails before it can validate port changes: GCC rejects std::sqrtf/std::fmodf in math.h-based sources, the inherited matching matrix cannot pull its private container, and the audio integration test waits for proprietary game files absent from public runners.

- Use the existing global float math declarations, retaining float precision.
- Run the private matching workflow by manual dispatch. It still requires access to the original container/toolchain/game files; automatic public Linux validation remains enabled.
- Return CTest skip code 77 when the extracted audio directory is absent. The audio integration test stays enabled for developer checkouts with assets; the other 21 offline tests still run.
- Install the already documented GBM/DRM/Mesa graphics runtime in the clean-distro job; SDL2 and non-driver libraries still come from the package.
- Transfer the standalone package as a tar archive, preserving executable bits on the bundled loader and binaries and extracting into nectar-linux. Resolve dependencies with the packaged loader instead of injecting its libc into the host ldd.

Validation: upstream PR CI and fork CI are green on fab3f170. Linux USA/PAL builds, 21 offline tests, standalone packaging, artifact round-trip and clean Debian 12 launcher/dependency smoke pass. The asset-backed audio test is explicitly skipped on source-only runners. Maintained downstream Windows production game/probe builds and 76 Python tests pass; a private asset-free invocation verifies return code77. No claim of private matching validation or asset-backed audio validation on public CI.

Upstream CI: https://github.com/SSunnKing/Open-Nectar---Pikmin-Native-PC-Port/actions/runs/34637042965
