### PR TITLE
Fix quick-release Pikmin grabs on PC

### DIFF
--- a/src/plugPikiKando/naviState.cpp
+++ b/src/plugPikiKando/naviState.cpp
@@ -2100,6 +2100,9 @@ void NaviThrowWaitState::exec(Navi* navi)
 			}
 			if (!mPendingThrowPiki->isAlive()) {
 				transit(navi, NAVISTATE_Walk);
+#if defined(PIKI_PC_PORT)
+				return;
+#endif
 			}
 			Vector3f diff = mPendingThrowPiki->mSRT.t - navi->mSRT.t;
 			f32 d         = diff.length();
@@ -2127,13 +2130,26 @@ void NaviThrowWaitState::exec(Navi* navi)
 
 	if (mHeldThrowPiki) {
 		int state = mHeldThrowPiki->getState();
+#if defined(PIKI_PC_PORT)
+		// A nearby selection remains Normal until KEY_Action0 completes the
+		// grab. Rejecting it here loses taps before the animation can attach it.
+		const bool awaitingGrab = !mIsHoldingThrowPiki && state == PIKISTATE_Normal;
+		if (!mHeldThrowPiki->isAlive() || (!awaitingGrab && state != PIKISTATE_Hanged && state != PIKISTATE_GoHang)) {
+#else
 		if (state != PIKISTATE_Hanged && state != PIKISTATE_GoHang) {
+#endif
 			transit(navi, NAVISTATE_Walk);
 			return;
 		}
 	}
 
-	if (navi->mKontroller->keyUp(KeyConfig::_instance->mThrowKey.mBind)) {
+	if (navi->mKontroller->keyUp(KeyConfig::_instance->mThrowKey.mBind)
+#if defined(PIKI_PC_PORT)
+	    // keyUp is level-triggered: a quick release remains pending while the
+	    // Pikmin approaches and the grab animation finishes.
+	    && mIsHoldingThrowPiki
+#endif
+	) {
 		sortPikis(navi);
 		navi->mThrowHoldTime = mThrowChargeLevel / 3.0f * C_NAVI_PARM(navi, mThrowHoldMaxTime);
 		transit(navi, NAVISTATE_Throw);


### PR DESCRIPTION
A short press and release of the throw button can be lost while a nearby Pikmin is still waiting for the grab animation, or while a farther Pikmin approaches. Keep the selected live Pikmin valid during that preparation and defer the throw transition until attachment completes. Also return immediately after cancelling a dead pending target.

PC-only; non-PC behavior is unchanged. This is one source-file patch based directly on current upstream main f80a7246, with no randomizer or other PR changes.

Validation: the same fix passed downstream real-engine animation/state regressions for nearby and approaching Pikmin with A already released: both reach the Flying state. This is state-machine coverage, not physical SDL/controller input acceptance. The downstream fixture and evidence are documented in [the implementation record](https://github.com/4laric/pikmin-randomizer/blob/main/DEVELOPMENT.md#quick-release-grab-timing-62). Fresh upstream CI will run on this branch; that evidence is separate from the downstream fixture.
