### PR TITLE
Preserve color-write masks around post-processing

### DIFF
--- a/pc_port/gl/pc_gfx.cpp
+++ b/pc_port/gl/pc_gfx.cpp
@@ -3011,6 +3011,15 @@ static GLuint post_apply()
     // Any of these failing means no post-processing, never a stopped frame.
     if (!post_ensure_target() || !post_ensure_program()) return sNativeFramebuffer;
 
+    // GX can leave colour or alpha writes disabled for the last scene draw.
+    // Every post target is a replacement image, so inheriting that mask can
+    // silently preserve stale channels (or the entire previous frame). Keep
+    // the GX mirrors untouched: save the actual GL mask and restore it after
+    // the chain, including when this function is called from present().
+    GLboolean colourMask[4] = { GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE };
+    glGetBooleanv(GL_COLOR_WRITEMASK, colourMask);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+
     // Every pass below draws a full-screen triangle, and none of them wants the
     // game's pipeline state. This has to happen BEFORE the chains, not just
     // before the composite: they are draws too.
@@ -3151,6 +3160,7 @@ static GLuint post_apply()
     // disabled blend/depth/cull and resized the viewport, so the GX
     // setters' redundancy guards are now lying.
     invalidate_gl_pipeline_guards();
+    glColorMask(colourMask[0], colourMask[1], colourMask[2], colourMask[3]);
     return sPostFramebuffer;
 }
 


### PR DESCRIPTION
GX can leave color or alpha writes disabled after the last scene draw. The post-processing chain inherits that mask and can preserve stale channels or an entire previous frame instead of replacing its render targets.

Save the actual GL color-write mask, enable all channels for the post-process chain, and restore the mask afterward. Existing GX state mirrors are left intact. This patch does not change presets, defaults, shaders, or effect tuning.

One source-file patch based directly on current upstream main f80a7246. The same implementation passed downstream real-OpenGL bloom, FXAA and grading checks with disabled/mixed masks, poisoned destination pixels and mask-restoration assertions. [Fixture and test scope](https://github.com/4laric/pikmin-randomizer/blob/main/engine/tools/GRAPHICS_VALIDATION.md). Fresh upstream CI runs separately; the downstream GL fixture is not presented as an upstream CI test.
