### PR TITLE
Continue initiated plucking while the extract button is held on PC

### DIFF
--- a/src/plugPikiKando/naviState.cpp
+++ b/src/plugPikiKando/naviState.cpp
@@ -2514,6 +2514,12 @@ void NaviNukuState::exec(Navi* navi)
 	navi->mVelocity.set(0.0f, 0.0f, 0.0f);
 	navi->mTargetVelocity.set(0.0f, 0.0f, 0.0f);
 
+#if defined(PIKI_PC_PORT)
+	// Holding continues an already-started pluck; release/cancel clears the
+	// request rather than leaving another pluck queued.
+	mWantsNextPluck = navi->mKontroller->keyDown(KeyConfig::_instance->mExtractKey.mBind)
+	    && !navi->mKontroller->keyDown(KeyConfig::_instance->mSetCursorKey.mBind);
+#else
 	if (!mExtractKeyReleased && navi->mKontroller->keyUp(KeyConfig::_instance->mExtractKey.mBind)) {
 		mExtractKeyReleased = true;
 	}
@@ -2523,6 +2529,7 @@ void NaviNukuState::exec(Navi* navi)
 		navi->mIsPlucking;
 		navi->mFastPluckKeyTaps++;
 	}
+#endif
 	navi->mTargetVelocity.set(0.0f, 0.0f, 0.0f);
 	navi->mPressedTimer += gsys->getFrameTime();
 	navi->mPressedTimer = -1000.0f;
@@ -2567,6 +2574,13 @@ void NaviNukuState::procAnimMsg(Navi* navi, MsgAnim* msg)
 	case KEY_Finished:
 	{
 		navi->_810 = 0;
+#if defined(PIKI_PC_PORT)
+		// Read current input at the animation boundary too. Count at most one
+		// continuation per sprout, not one fast-pluck tap per rendered frame.
+		mWantsNextPluck = navi->mKontroller->keyDown(KeyConfig::_instance->mExtractKey.mBind)
+		    && !navi->mKontroller->keyDown(KeyConfig::_instance->mSetCursorKey.mBind);
+		if (mWantsNextPluck) navi->mFastPluckKeyTaps = 1;
+#endif
 		if (mWantsNextPluck) {
 			if (!navi->procActionButton()) {
 				mWantsNextPluck = false;


### PR DESCRIPTION
After the player initiates plucking, allow holding the mapped extract button to continue to the next sprout. Releasing it or holding whistle cancels continuation. Sample the current input again at the animation boundary so a release between updates cannot leave another pluck queued, and set the fast-pluck continuation count once per sprout instead of accumulating it per frame.

This is an intentional PC quality-of-life change. Initial pluck initiation, next-sprout selection/range and non-PC behavior remain unchanged. One source-file patch based directly on current upstream main f80a7246; no quick-grab, whistle-tuning, randomizer or CI changes are included.

The same implementation passed downstream real-engine tests for uninterrupted hold, release, whistle cancellation, re-press, release before KEY_Finished and bounded fast-pluck count. [Test scope and reproduction](https://github.com/4laric/pikmin-randomizer/blob/main/DEVELOPMENT.md#hold-to-continue-initiated-plucking-66). These are input/state regressions, not a physical controller or full multi-sprout playthrough. Fresh upstream CI runs separately.
