### PR TITLE
Prevent bomb placement warnings from interrupting other carriers on PC

### DIFF
--- a/src/plugPikiKando/interactEtc.cpp
+++ b/src/plugPikiKando/interactEtc.cpp
@@ -37,6 +37,14 @@ bool InteractWarn::actPiki(Piki* piki) immut
 		return false;
 	}
 
+#if defined(PIKI_PC_PORT)
+	// A placement warning must not recall another carrier before it can
+	// deploy its bomb. Real blast damage and player whistles are separate.
+	if (piki->hasBomb()) {
+		return false;
+	}
+#endif
+
 	if (piki->isKinoko() || !piki->mIsCallable || piki->mMode == 1) {
 		return false;
 	}


### PR DESCRIPTION
When several yellow Pikmin are deploying bombs together, one planter's warning can send another bomb carrier into LookAt or queue a whistle recall before it places its bomb. On PC, ignore InteractWarn for Pikmin that still hold a bomb. Ordinary Pikmin retain their warning reaction; player whistle and actual blast damage use separate paths.

This is an eight-line change in one source file, based on current main 7dc430c7. It contains no randomizer integration or balance changes.

Validation: the downstream real-engine regression reproduces the old failure (warning interrupted a bomb carrier) and passes with this guard. It dispatches the actual ActPutBomb warning to live Pikmin, checks multiple carriers, ordinary reactions, pending-recall suppression and reactions after releasing the held predicate. The fixture uses temporary held-creature sentinels; it does not simulate a complete bomb/wall deployment. Downstream Windows production build passed; full player multi-bomb/wall acceptance remains pending. Upstream CI will validate this branch separately.
