### PR TITLE
Honor remapped controller actions in the new-game prompt

### DIFF
--- a/pc_port/settings/pc_settings.cpp
+++ b/pc_port/settings/pc_settings.cpp
@@ -908,6 +908,26 @@ bool padNavRight(SDL_GameController* c)
 bool padNavA(SDL_GameController* c) { return padEdge(SDL_GameControllerGetButton(c, SDL_CONTROLLER_BUTTON_A), 4); }
 bool padNavB(SDL_GameController* c) { return padEdge(SDL_GameControllerGetButton(c, SDL_CONTROLLER_BUTTON_B), 5); }
 
+// The new-game prompt is a game-facing dialog rather than the F1 settings
+// menu. Its accept/cancel actions follow the configured A/B bindings, which
+// may be either SDL buttons or the axis encodings used by the remapping page.
+// Keep these separate from padNavA/B: F1 navigation deliberately retains its
+// physical A/B convention.
+bool promptPadBinding(SDL_GameController* c, int action, int edgeSlot)
+{
+	return c && padEdge(pc_window_gamepad_bind_held(c, pc_window_get_gamepad_binding(action)), edgeSlot);
+}
+
+bool promptPadA(SDL_GameController* c)
+{
+	return promptPadBinding(c, PC_KEY_ACT_A, 4);
+}
+
+bool promptPadB(SDL_GameController* c)
+{
+	return promptPadBinding(c, PC_KEY_ACT_B, 5);
+}
+
 bool captureConfirmHeld(SDL_GameController* ctl)
 {
 	int numKeys = 0;
@@ -1972,8 +1992,8 @@ void pcNewGamePromptInput() {
     if (ctl) {
         if (padNavLeft(ctl))  left   = true;
         if (padNavRight(ctl)) right  = true;
-        if (padNavA(ctl))     accept = true;
-        if (padNavB(ctl))     cancel = true;
+        if (promptPadA(ctl))  accept = true;
+        if (promptPadB(ctl))  cancel = true;
     }
 
     if (left || right) sNewGamePromptChoice = sNewGamePromptChoice ? 0 : 1;


### PR DESCRIPTION
The new-game normal/permadeath prompt currently reads physical controller A/B even after those actions are remapped. Resolve its accept/cancel input through the configured gameplay bindings, including analog-axis bindings. F1 navigation keeps its existing physical A/B convention.

Fixes #21.

Validation: a local SDL virtual-controller harness using extracted production binding and edge helpers passed default and swapped buttons, positive/negative axis bindings, held-input suppression, and unchanged physical F1 helpers. `git diff --check` passes. Full in-game prompt testing remains outstanding; the standalone harness does not render the prompt.
