### PR TITLE
Toggle the settings menu with controller Select/View

### DIFF
--- a/pc_port/settings/pc_settings.cpp
+++ b/pc_port/settings/pc_settings.cpp
@@ -231,6 +231,10 @@ bool sHadConfigFile = false;
 bool sMenuOpen = false;
 int sSelection = ROW_DISPLAY_MODE;
 static std::vector<Uint8> gPrevKeys; // previous-frame keyboard state snapshot
+// SDL calls the Xbox Select/View button BACK.  Keep its edge independently of
+// the keyboard snapshot: settings input is polled from more than one hook per
+// frame, and a held button must not reopen the menu after a modal closes.
+bool sPrevMenuToggleHeld = false;
 
 // Video confirm/revert dialog state.
 bool sVideoConfirmActive = false;
@@ -947,6 +951,15 @@ void latchKeys() {
 void pcNewGamePromptInput();
 
 void pollMenuInput() {
+    SDL_GameController* ctl = pc_window_get_controller();
+    const bool menuToggleHeld = ctl && SDL_GameControllerGetButton(
+        ctl, SDL_CONTROLLER_BUTTON_BACK) != 0;
+    const bool menuTogglePressed = menuToggleHeld && !sPrevMenuToggleHeld;
+    // Latch before every modal early return.  A Select press used while the
+    // new-game/video/capture modal owns input must not become a fresh press
+    // when that modal exits while the button is still held.
+    sPrevMenuToggleHeld = menuToggleHeld;
+
     if (pc_newgame_prompt_active()) {
         // The prompt owns input while it is up, including F1: opening the
         // settings menu over a modal that is deciding a save file's rules
@@ -955,28 +968,31 @@ void pollMenuInput() {
         return;
     }
 
-    // F1 toggles the menu.
+    auto openMenu = [] {
+        sPending = sConfig;
+        sPending.controlMode = pc_window_get_control_mode();
+        sMenuOpen = true;
+        pc_window_set_settings_menu_open(true);
+        sSelection = ROW_DISPLAY_MODE;
+        sVideoConfirmActive = false;
+        rebuildResolutionList();
+        const int idx = resolutionIndexFor(pc_window_get_width(), pc_window_get_height());
+        sResolutionIdx = idx >= 0 ? idx : defaultResolutionIndex();
+    };
+
+    // F1 always toggles. Select/View can open the menu while it is closed;
+    // closing is handled after video confirmation has had first refusal.
     if (keyWentDown(SDL_SCANCODE_F1)) {
-        if (sMenuOpen) {
-            closeMenu();
-        } else {
-            sPending = sConfig;
-            sPending.controlMode = pc_window_get_control_mode();
-            sMenuOpen = true;
-            pc_window_set_settings_menu_open(true);
-            sSelection = ROW_DISPLAY_MODE;
-            sVideoConfirmActive = false;
-            rebuildResolutionList();
-            const int idx = resolutionIndexFor(pc_window_get_width(), pc_window_get_height());
-            sResolutionIdx = idx >= 0 ? idx : defaultResolutionIndex();
-        }
+        if (sMenuOpen) closeMenu();
+        else openMenu();
+        return;
+    }
+    if (menuTogglePressed && !sMenuOpen) {
+        openMenu();
         return;
     }
 
     if (!sMenuOpen) return;
-
-    // Poll gamepad state for menu navigation.
-    SDL_GameController* ctl = pc_window_get_controller();
 
     // Modal video-confirm dialog.
     if (sVideoConfirmActive) {
@@ -996,6 +1012,16 @@ void pollMenuInput() {
                    (ctl && padNavB(ctl))) {
             revertVideoSettings();
         }
+        return;
+    }
+
+    // Select/View closes the menu from ordinary pages and submenus.  Capture
+    // owns the button while waiting for a binding (including the short
+    // wait-release period after accepting one), so it can be assigned or
+    // released without toggling the menu underneath.
+    if (menuTogglePressed && !sWaitingForKey && !sWaitingForButton &&
+        !sCaptureWaitRelease) {
+        closeMenu();
         return;
     }
 


### PR DESCRIPTION
Allow the controller Select/View (SDL BACK) button to open and close the F1 settings menu. Latch its press before modal returns so holding it cannot reopen the menu after a dialog exits. Video confirmation and binding capture retain ownership of their input, and F1 keeps its existing behavior.

Fixes #20.

Validation: a local SDL virtual-controller harness running the extracted production menu-routing block passed open/close, held-button suppression, new-game and video modal handling, keyboard/button capture and release waiting, and F1 opening. Unrelated UI functions were stubbed; full in-game testing remains outstanding. `git diff --check` passes.
