### PR TITLE
Improve first-run disc conversion, progress and recovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,12 +450,13 @@ else()
     set(LAUNCHER_PLATFORM_SOURCE pc_port/launcher/launcher_platform_posix.cpp)
 endif()
 
+find_package(Threads REQUIRED)
 add_executable(pikmin_launcher
     pc_port/launcher/launcher_main.cpp
     pc_port/launcher/installer_ui.cpp
     ${LAUNCHER_PLATFORM_SOURCE})
 target_include_directories(pikmin_launcher PRIVATE ${SDL2_INCLUDE_DIRS})
-target_link_libraries(pikmin_launcher PRIVATE pikmin_disc_image ${SDL2_LIBRARIES})
+target_link_libraries(pikmin_launcher PRIVATE pikmin_disc_image ${SDL2_LIBRARIES} Threads::Threads)
 if (WIN32)
     # Diálogo de archivo clásico, selector de carpeta del shell y COM.
     target_link_libraries(pikmin_launcher PRIVATE comdlg32 ole32 shell32 uuid)
@@ -488,6 +489,18 @@ enable_testing()
 add_test(NAME gamecube_image_test COMMAND gamecube_image_test)
 add_test(NAME sha256_test COMMAND sha256_test)
 add_test(NAME installer_ui_test COMMAND installer_ui_test)
+
+add_executable(asset_finalize_test pc_port/launcher/asset_finalize_test.cpp)
+target_link_libraries(asset_finalize_test PRIVATE Threads::Threads)
+target_compile_options(asset_finalize_test PRIVATE ${NATIVE_COMPILE_OPTIONS})
+add_test(NAME asset_finalize_test COMMAND asset_finalize_test)
+
+add_executable(prepared_image_test pc_port/launcher/prepared_image_test.cpp ${LAUNCHER_PLATFORM_SOURCE})
+target_compile_options(prepared_image_test PRIVATE ${NATIVE_COMPILE_OPTIONS})
+if (WIN32)
+    target_link_libraries(prepared_image_test PRIVATE comdlg32 ole32 shell32 uuid)
+endif()
+add_test(NAME prepared_image_test COMMAND prepared_image_test)
 
 add_executable(pc_generator_cache_validation_test
     pc_port/save/pc_generator_cache_validation_test.cpp)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Everything else — glibc, SDL2, audio libraries — travels inside the package,
 1. Extract `nectar-windows.zip` anywhere. There is no installer to run and
    nothing is written outside the folder you choose.
 2. Run `nectar-launcher.exe`.
-3. It asks for your Pikmin ISO or GCM, and then for a folder to install into.
+3. It asks for your Pikmin disc image, and then for a folder to install into.
    Any folder works.
 4. It verifies the image, extracts the assets and starts the game.
 
@@ -85,6 +85,27 @@ Installation takes a minute or two, most of it verifying that the disc image is
 intact and that every extracted file came out right. That check catches damaged
 copies and failing drives, which are the usual reason a game installs fine and
 then misbehaves later.
+
+ISO/GCM works without additional tools. For RVZ/WIA/GCZ, the launcher uses
+**DolphinTool.exe** on Windows or **dolphin-tool** on Linux from an existing
+[Dolphin installation](https://dolphin-emu.org/download/). It looks beside the
+launcher and on PATH, then offers a file picker if the tool was not found.
+Keep the tool with the rest of its Dolphin installation. It is not downloaded
+or included by Open Nectar.
+
+Conversion needs about **1.4 GiB extra free space in your system's temporary
+folder**. The source image is unchanged; a separate temporary ISO is verified,
+extracted, and removed when the attempt finishes. An interrupted conversion is
+never reused. Forced termination may leave a `nectar-disc-*` temporary folder;
+remove it only after the launcher and converter have stopped.
+
+The progress display identifies conversion, disc verification, extraction and
+finishing separately. If setup fails, **Back to setup** keeps your selections
+so you can correct the image, converter or destination. Temporary file locks
+at the final extraction step are retried for up to 2.5 seconds; persistent
+failures show the preserved extraction path instead of silently starting over.
+
+Once the game starts, **F1** opens graphics, controls and gameplay settings.
 
 **Playing afterwards**
 
@@ -104,6 +125,9 @@ nectar-launcher.exe --rom C:\path\to\Pikmin.iso --install-dir C:\Games\OpenNecta
 
 Add `--extract-only` to install without launching the game afterwards. This
 works over Remote Desktop and on machines with no desktop session.
+For a compressed image, add `--dolphin-tool C:\path\to\DolphinTool.exe` if
+the converter is not beside the launcher or on PATH. The same option accepts
+the path to `dolphin-tool` on Linux.
 
 **The console window is intentional**
 
@@ -133,11 +157,12 @@ To move the installation elsewhere, copy the folder. To remove it, delete it.
 | Closes instantly, no window | `SDL2.dll` is missing from the folder, or Windows blocked it |
 | "Could not initialize window/OpenGL" | Graphics drivers too old, or the generic Windows display driver |
 | Starts but finds no data | Run it from the installation folder, not from elsewhere |
-| The image is rejected | It must be Pikmin USA Rev 1 or Pikmin Europe, uncompressed. Convert RVZ/WIA/GCZ to ISO with `dolphin-tool` |
+| The image is rejected | It must be Pikmin USA Rev 1 or Pikmin Europe. RVZ/WIA/GCZ also needs the Dolphin converter; ISO/GCM does not |
+| Disc conversion fails | Check the temporary folder's free space and select the converter from a complete Dolphin installation, or use ISO/GCM |
 
 ### Both platforms
 
-The launcher asks for your ISO/GCM, extracts the assets it needs and starts the
+The launcher asks for your disc image, extracts the assets it needs and starts the
 game. Your disc image is never copied or modified.
 
 Supported discs:

--- a/pc_port/launcher/asset_finalize.h
+++ b/pc_port/launcher/asset_finalize.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <chrono>
+#include <filesystem>
+#include <system_error>
+#include <thread>
+
+namespace pikmin::launcher {
+
+// A scanner may briefly hold newly extracted files open on Windows. Bound the
+// finalization delay to 2.5 seconds (five attempts); never repeat extraction.
+template <typename Rename, typename Wait>
+std::error_code retryAssetRename(Rename rename, Wait wait)
+{
+    for (int attempt = 0; attempt < 5; ++attempt) {
+        const std::error_code ec = rename();
+        const bool transient = ec == std::errc::permission_denied
+                            || ec == std::errc::device_or_resource_busy;
+        if (!ec || !transient || attempt == 4) return ec;
+        wait(std::chrono::milliseconds(250 * (attempt + 1)));
+    }
+    return {}; // All paths return inside the bounded loop.
+}
+
+inline std::error_code finalizeAssets(const std::filesystem::path& partial,
+                                     const std::filesystem::path& destination)
+{
+    return retryAssetRename([&] {
+        std::error_code ec;
+        if (std::filesystem::exists(destination, ec))
+            return std::make_error_code(std::errc::file_exists);
+        if (ec) return ec;
+        std::filesystem::rename(partial, destination, ec);
+        return ec;
+    }, [](std::chrono::milliseconds delay) { std::this_thread::sleep_for(delay); });
+}
+
+} // namespace pikmin::launcher

--- a/pc_port/launcher/asset_finalize_test.cpp
+++ b/pc_port/launcher/asset_finalize_test.cpp
@@ -1,0 +1,91 @@
+#include "asset_finalize.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+void check(bool condition, const char* message)
+{
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+int main()
+{
+    using namespace pikmin::launcher;
+    using namespace std::chrono;
+
+    int calls = 0;
+    std::vector<int> delays;
+    auto wait = [&](milliseconds delay) { delays.push_back(static_cast<int>(delay.count())); };
+    const auto denied = std::make_error_code(std::errc::permission_denied);
+    auto ec = retryAssetRename([&] { return ++calls < 3 ? denied : std::error_code{}; }, wait);
+    check(!ec && calls == 3 && delays == std::vector<int>({250, 500}), "transient recovery");
+
+    calls = 0;
+    delays.clear();
+    const auto busy = std::make_error_code(std::errc::device_or_resource_busy);
+    ec = retryAssetRename([&] { return ++calls == 1 ? busy : std::error_code{}; }, wait);
+    check(!ec && calls == 2 && delays == std::vector<int>({250}), "busy recovery");
+
+    calls = 0;
+    delays.clear();
+    ec = retryAssetRename([&] { ++calls; return denied; }, wait);
+    check(ec == denied && calls == 5 && delays == std::vector<int>({250, 500, 750, 1000}),
+          "bounded exhaustion");
+
+    calls = 0;
+    delays.clear();
+    const auto missing = std::make_error_code(std::errc::no_such_file_or_directory);
+    ec = retryAssetRename([&] { ++calls; return missing; }, wait);
+    check(ec == missing && calls == 1 && delays.empty(), "permanent failure is immediate");
+
+    namespace fs = std::filesystem;
+    const auto root = fs::temp_directory_path()
+                    / ("nectar finalize test "
+                       + std::to_string(steady_clock::now().time_since_epoch().count()));
+    check(fs::create_directory(root), "unique scratch directory");
+    const auto partial = root / "assets.partial";
+    const auto final = root / "assets";
+    check(fs::create_directory(partial), "partial directory");
+    {
+        std::ofstream file(partial / "marker");
+        file << "preserve me";
+    }
+    check(fs::create_directory(final), "destination directory");
+    check(finalizeAssets(partial, final) == std::errc::file_exists,
+          "existing destination rejected");
+    check(fs::exists(partial / "marker"), "failed finalization preserves extraction");
+    fs::remove(final);
+
+#ifdef _WIN32
+    HANDLE lock = CreateFileW(partial.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                              nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+    check(lock != INVALID_HANDLE_VALUE, "acquire real directory lock");
+    fs::rename(partial, final, ec);
+    check(bool(ec), "lock prevents initial rename");
+    std::thread release([&] {
+        std::this_thread::sleep_for(milliseconds(300));
+        CloseHandle(lock);
+    });
+    ec = finalizeAssets(partial, final);
+    release.join();
+#else
+    ec = finalizeAssets(partial, final);
+#endif
+
+    check(!ec && fs::exists(final / "marker") && !fs::exists(partial),
+          "real directory finalization");
+    fs::remove(final / "marker");
+    fs::remove(final);
+    fs::remove(root);
+    std::cout << "PASS bounded retry, permanent errors, destination preservation and filesystem finalization\n";
+}

--- a/pc_port/launcher/installer_ui.cpp
+++ b/pc_port/launcher/installer_ui.cpp
@@ -48,7 +48,7 @@ const Glyph& glyphFor(char input)
         { '5', { 31, 16, 16, 30, 1, 1, 30 } }, { '6', { 14, 16, 16, 30, 17, 17, 14 } },
         { '7', { 31, 1, 2, 4, 8, 8, 8 } }, { '8', { 14, 17, 17, 14, 17, 17, 14 } },
         { '9', { 14, 17, 17, 15, 1, 1, 14 } }, { '.', { 0, 0, 0, 0, 0, 12, 12 } },
-        { '/', { 1, 2, 2, 4, 8, 8, 16 } }, { ':', { 0, 12, 12, 0, 12, 12, 0 } },
+        { ',', { 0, 0, 0, 0, 4, 4, 8 } }, { '/', { 1, 2, 2, 4, 8, 8, 16 } }, { ':', { 0, 12, 12, 0, 12, 12, 0 } },
         { '-', { 0, 0, 0, 31, 0, 0, 0 } }, { '_', { 0, 0, 0, 0, 0, 0, 31 } },
         { '(', { 2, 4, 8, 8, 8, 4, 2 } }, { ')', { 8, 4, 2, 2, 2, 4, 8 } },
         { '%', { 17, 2, 4, 8, 17, 0, 0 } }, { '?', { 14, 17, 1, 2, 4, 0, 4 } }
@@ -163,11 +163,18 @@ struct InstallerWindow::Impl {
         drawButton(installButton, installing ? "Installing" : "Install",
                    contains(installButton, mouseX, mouseY), rom.empty() || installDirectory.empty() || installing);
 
+        drawText(renderer, 45, 279, "In game: F1 opens graphics, controls and gameplay settings", 1,
+                 { 180, 197, 214, 255 });
+
         if (installing) {
             SDL_Rect track { 45, 373, 670, 12 };
             fillRect(renderer, track, { 36, 50, 70, 255 });
             SDL_Rect bar = track;
             bar.w = static_cast<int>(track.w * std::min(progress, 100u) / 100u);
+            if (progress > 100) {
+                bar.w = 100;
+                bar.x += static_cast<int>((SDL_GetTicks() / 8) % (track.w - bar.w));
+            }
             fillRect(renderer, bar, { 116, 185, 92, 255 });
         }
         drawText(renderer, 45, 400, fitPath(status, 670, 1), 1, { 180, 197, 214, 255 });
@@ -257,6 +264,10 @@ bool InstallerWindow::choosePaths(const std::function<std::string()>& chooseRom,
                                   const std::function<std::string()>& chooseInstallDirectory,
                                   std::string& rom, std::string& installDirectory)
 {
+    mImpl->installing = false;
+    mImpl->progress = 0;
+    mImpl->status = "Choose your disc image and where to install";
+    mImpl->render();
     SDL_Event event;
     bool pendingRedraw = false;
     for (;;) {
@@ -302,11 +313,32 @@ bool InstallerWindow::choosePaths(const std::function<std::string()>& chooseRom,
     return false;
 }
 
-void InstallerWindow::updateProgress(std::uint32_t percent, const std::string& currentFile)
+void InstallerWindow::updateProgress(std::uint32_t percent, const std::string& currentFile,
+                                     const std::string& phase)
 {
+    mImpl->installing = true;
     mImpl->progress = percent;
-    mImpl->status = "Extrayendo (" + std::to_string(percent) + "%): " + currentFile;
+    mImpl->status = phase + (percent <= 100 ? " (" + std::to_string(percent) + "%)" : "...");
+    if (!currentFile.empty()) {
+        const int remaining = 670 - textWidth(mImpl->status + ": ", 1);
+        mImpl->status += ": " + fitPath(currentFile, remaining, 1);
+    }
     mImpl->pump();
+}
+
+bool InstallerWindow::offerRetry(const std::string& message)
+{
+    mImpl->installing = false;
+    mImpl->status = "Installation did not finish";
+    mImpl->render();
+    const SDL_MessageBoxButtonData buttons[] = {
+        { SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 0, "Close" },
+        { SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, "Back to setup" }
+    };
+    const SDL_MessageBoxData data { SDL_MESSAGEBOX_ERROR, mImpl->window, "Open Nectar Installer",
+                                   message.c_str(), 2, buttons, nullptr };
+    int selected = 0;
+    return SDL_ShowMessageBox(&data, &selected) == 0 && selected == 1;
 }
 
 void InstallerWindow::showError(const std::string& message)
@@ -323,6 +355,8 @@ void InstallerWindow::showComplete(const std::string& installDirectory, bool wil
     mImpl->status = "Installation complete";
     mImpl->render();
     std::string message = "Open Nectar is installed in:\n" + installDirectory;
+    message += "\n\nF1 opens graphics, controls and gameplay settings."
+               "\nRun nectar-launcher from this folder to play again.";
     if (willLaunch) message += "\n\nThe game will start now.";
     SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "Installation complete", message.c_str(), mImpl->window);
 }

--- a/pc_port/launcher/installer_ui.h
+++ b/pc_port/launcher/installer_ui.h
@@ -19,8 +19,11 @@ public:
     bool choosePaths(const std::function<std::string()>& chooseRom,
                      const std::function<std::string()>& chooseInstallDirectory,
                      std::string& rom, std::string& installDirectory);
-    void updateProgress(std::uint32_t percent, const std::string& currentFile);
+    // Percent > 100 means an indeterminate phase (external disc conversion).
+    void updateProgress(std::uint32_t percent, const std::string& currentFile,
+                        const std::string& phase = "Extracting");
     void showError(const std::string& message);
+    bool offerRetry(const std::string& message);
     void showComplete(const std::string& installDirectory, bool willLaunch);
 
 private:

--- a/pc_port/launcher/installer_ui_test.cpp
+++ b/pc_port/launcher/installer_ui_test.cpp
@@ -14,6 +14,30 @@ int main()
         return 1;
     }
     window.updateProgress(50, "dataDir/test/file.bin");
-    std::puts("installer_ui_test: window and progress rendering passed");
+    window.updateProgress(101, "Preparing a temporary ISO", "Converting disc");
+    window.updateProgress(50, "", "Checking disc");
+    window.updateProgress(100, "", "Finishing");
+
+    const auto click = [](int x, int y) {
+        SDL_Event event {};
+        event.type = SDL_MOUSEBUTTONUP;
+        event.button.button = SDL_BUTTON_LEFT;
+        event.button.x = x;
+        event.button.y = y;
+        SDL_PushEvent(&event);
+    };
+    click(600, 140); // Choose the original compressed source.
+    click(600, 230);
+    click(300, 320);
+    std::string rom, directory;
+    if (!window.choosePaths([] { return "original.rvz"; }, [] { return "install"; }, rom, directory)
+        || rom != "original.rvz" || directory != "install") return 1;
+    // A failed attempt must return to setup with its original choices intact,
+    // not with the temporary ISO path used internally during conversion.
+    window.updateProgress(25, "", "Checking disc");
+    click(300, 320);
+    if (!window.choosePaths([] { return "unexpected"; }, [] { return "unexpected"; }, rom, directory)
+        || rom != "original.rvz" || directory != "install") return 1;
+    std::puts("installer_ui_test: phases and setup selection retention passed");
     return 0;
 }

--- a/pc_port/launcher/launcher_main.cpp
+++ b/pc_port/launcher/launcher_main.cpp
@@ -1,4 +1,6 @@
 #include "gamecube_image.h"
+#include "asset_finalize.h"
+#include "prepared_image.h"
 #include "installer_ui.h"
 #include "launcher_platform.h"
 
@@ -213,9 +215,13 @@ bool installAssets(const fs::path& image, const fs::path& dataRoot, std::string&
         fs::remove_all(partialAssets, ec);
         return false;
     }
-    fs::rename(partialAssets, finalAssets, ec);
+    if (progressCallback) progressCallback(100, "Finishing installation...");
+    ec = pikmin::launcher::finalizeAssets(partialAssets, finalAssets);
     if (ec) {
-        failure = "Could not finish the installation: " + ec.message();
+        failure = "Could not finish the installation: " + ec.message()
+                + ". Close programs using the install folder. The extracted files remain at "
+                + partialAssets.string()
+                + ". Choose another install folder, or remove that partial folder before trying again.";
         return false;
     }
     std::cout << "Game data installed in " << finalAssets << "\n";
@@ -492,7 +498,9 @@ void usage(const char* argv0)
               << "With no arguments it opens the graphical installer (needs zenity or kdialog);\n"
               << "from a terminal without those it falls back to the text installer.\n"
               << "The disc image must come from your own copy of Pikmin: USA Rev 1 or Europe.\n"
-              << "--skip-verify skips the image integrity check.\n";
+              << "--skip-verify skips the image integrity check.\n"
+              << "--dolphin-tool PATH enables RVZ/WIA/GCZ conversion (also found beside the launcher or on PATH).\n"
+              << "In game, F1 opens graphics, controls and gameplay settings.\n";
 }
 
 } // namespace
@@ -503,6 +511,7 @@ int main(int argc, char** argv)
     fs::path dataRoot;
     bool extractOnly = false;
     bool skipVerify = false;
+    fs::path converter;
     bool directoryWasSpecified = false;
     for (int i = 1; i < argc; ++i) {
         const std::string arg = argv[i];
@@ -511,6 +520,7 @@ int main(int argc, char** argv)
             dataRoot = argv[++i];
             directoryWasSpecified = true;
         }
+        else if (arg == "--dolphin-tool" && i + 1 < argc) converter = fs::absolute(argv[++i]);
         else if (arg == "--extract-only") extractOnly = true;
         else if (arg == "--skip-verify") skipVerify = true;
         else if (arg == "--help" || arg == "-h") { usage(argv[0]); return 0; }
@@ -527,149 +537,181 @@ int main(int argc, char** argv)
     const bool graphicalInstall = !directoryWasSpecified && !installedBesideLauncher;
     std::unique_ptr<pikmin::launcher::InstallerWindow> installerWindow;
     const auto reportError = [&installerWindow](const std::string& error) {
-        if (installerWindow) installerWindow->showError(error);
-        else std::cerr << "Installation error: " << error << '\n';
+        if (installerWindow) return installerWindow->offerRetry(error);
+        std::cerr << "Installation error: " << error << '\n';
+        return false;
     };
-    if (installedBesideLauncher) {
-        dataRoot = sourceDirectory;
-    } else if (graphicalInstall) {
-        if (hasGraphicalDialogs()) {
-            installerWindow = std::make_unique<pikmin::launcher::InstallerWindow>();
-            std::string error;
-            if (!installerWindow->open(error)) {
-                std::cerr << "Could not open the installer: " << error << '\n';
+    for (;;) {
+        if (installedBesideLauncher) {
+            dataRoot = sourceDirectory;
+        } else if (graphicalInstall) {
+            if (hasGraphicalDialogs()) {
+                if (!installerWindow) {
+                    installerWindow = std::make_unique<pikmin::launcher::InstallerWindow>();
+                    std::string error;
+                    if (!installerWindow->open(error)) {
+                        std::cerr << "Could not open the installer: " << error << '\n';
+                        return 1;
+                    }
+                }
+                std::string selectedRom;
+                std::string selectedInstallDirectory;
+                if (!installerWindow->choosePaths(
+                        [] { return askForImage().string(); },
+                        [] { return askForInstallDirectory().string(); },
+                        selectedRom, selectedInstallDirectory)) {
+                    return 0;
+                }
+                image = selectedRom;
+                dataRoot = selectedInstallDirectory;
+            } else if (stdinIsTerminal()) {
+                image = askForImageConsole();
+                if (image.empty()) {
+                    std::cerr << "No disc image was chosen.\n";
+                    return 1;
+                }
+                dataRoot = askForInstallDirectoryConsole();
+            } else {
+                if (respawnInTerminal()) return 0;
+                std::cerr << "The graphical installer needs Zenity or KDialog.\n"
+                             "Install zenity (Debian/Ubuntu: sudo apt install zenity; Arch: sudo pacman -S zenity)\n"
+                             "or run nectar-launcher from a terminal to use the text installer.\n";
                 return 1;
             }
-            std::string selectedRom;
-            std::string selectedInstallDirectory;
-            if (!installerWindow->choosePaths(
-                    [] { return askForImage().string(); },
-                    [] { return askForInstallDirectory().string(); },
-                    selectedRom, selectedInstallDirectory)) {
-                return 0;
-            }
-            image = selectedRom;
-            dataRoot = selectedInstallDirectory;
-        } else if (stdinIsTerminal()) {
-            image = askForImageConsole();
+        } else if (dataRoot.empty()) {
+            dataRoot = defaultDataRoot();
+        }
+
+        bool installedAssetsNow = false;
+        if (!assetsReady(dataRoot)) {
+            if (image.empty() && hasGraphicalDialogs()) image = askForImage();
+            if (image.empty() && stdinIsTerminal()) image = askForImageConsole();
             if (image.empty()) {
+                if (installerWindow) return 0;
                 std::cerr << "No disc image was chosen.\n";
                 return 1;
             }
-            dataRoot = askForInstallDirectoryConsole();
-        } else {
-            if (respawnInTerminal()) return 0;
-            std::cerr << "The graphical installer needs Zenity or KDialog.\n"
-                         "Install zenity (Debian/Ubuntu: sudo apt install zenity; Arch: sudo pacman -S zenity)\n"
-                         "or run nectar-launcher from a terminal to use the text installer.\n";
-            return 1;
-        }
-    } else if (dataRoot.empty()) {
-        dataRoot = defaultDataRoot();
-    }
-
-    bool installedAssetsNow = false;
-    if (!assetsReady(dataRoot)) {
-        if (image.empty() && hasGraphicalDialogs()) image = askForImage();
-        if (image.empty() && stdinIsTerminal()) image = askForImageConsole();
-        if (image.empty()) {
-            if (installerWindow) return 0;
-            std::cerr << "No disc image was chosen.\n";
-            return 1;
-        }
-        const std::string ext = lowerExtension(image);
-        if (ext != ".iso" && ext != ".gcm") {
-            const std::string error = "The installer takes ISO/GCM. Convert RVZ/WIA/GCZ to ISO with dolphin-tool.";
-            reportError(error);
-            return 1;
-        }
-        // Comprobar la imagen antes de extraer: evita instalar durante minutos
-        // desde una copia dañada y que el fallo aparezca mucho después, ya en
-        // el juego, como un error incomprensible.
-        if (!skipVerify) {
-            if (installerWindow) installerWindow->updateProgress(0, "Checking the image...");
-            else std::cout << "Checking the image..." << std::flush;
-            std::string verifyError;
-            const auto verifyProgress = [&installerWindow](std::uint32_t percent) {
-                if (installerWindow) {
-                    installerWindow->updateProgress(percent, "Checking the image...");
+            pikmin::launcher::PreparedImage prepared;
+            if (pikmin::launcher::isCompressedImage(image)) {
+                if (converter.empty()) converter = platform::findConverter();
+                if (converter.empty() && installerWindow) converter = platform::askForConverter();
+                if (converter.empty()) {
+                    if (reportError("Compressed images need dolphin-tool from a Dolphin installation. "
+                                    "Choose it when prompted, or select an ISO/GCM. For command-line installs, "
+                                    "use --dolphin-tool PATH.")) continue;
+                    return 1;
                 }
-            };
-            if (!pikmin::launcher::verifyImageIntegrity(image, verifyError, verifyProgress)) {
-                if (!installerWindow) std::cout << '\n';
-                reportError(verifyError);
+                const auto pump = [&installerWindow] {
+                    if (installerWindow) installerWindow->updateProgress(101, "Preparing a temporary ISO", "Converting disc");
+                };
+                pump();
+                std::cout << "Converting the disc to a temporary ISO...\n";
+                std::string error;
+                if (!prepared.prepare(fs::absolute(image), [&](const fs::path& source, const fs::path& output, std::string& failure) {
+                        return platform::convertImage(converter, source, output, pump, failure);
+                    }, error)) {
+                    converter.clear();
+                    if (reportError(error)) continue;
+                    return 1;
+                }
+                image = prepared.image;
+            }
+            const std::string ext = lowerExtension(image);
+            if (ext != ".iso" && ext != ".gcm") {
+                const std::string error = "Choose an ISO/GCM, or an RVZ/WIA/GCZ with dolphin-tool available.";
+                if (reportError(error)) continue;
                 return 1;
             }
-            if (!installerWindow) std::cout << " ok.\n";
+            // Comprobar la imagen antes de extraer: evita instalar durante minutos
+            // desde una copia dañada y que el fallo aparezca mucho después, ya en
+            // el juego, como un error incomprensible.
+            if (!skipVerify) {
+                if (installerWindow) installerWindow->updateProgress(0, "", "Checking disc");
+                else std::cout << "Checking the image..." << std::flush;
+                std::string verifyError;
+                const auto verifyProgress = [&installerWindow](std::uint32_t percent) {
+                    if (installerWindow) {
+                        installerWindow->updateProgress(percent, "", "Checking disc");
+                    }
+                };
+                if (!pikmin::launcher::verifyImageIntegrity(image, verifyError, verifyProgress)) {
+                    if (!installerWindow) std::cout << '\n';
+                    if (reportError(verifyError)) continue;
+                    return 1;
+                }
+                if (!installerWindow) std::cout << " ok.\n";
+            }
+
+            std::string failure;
+            const auto progress = [&installerWindow](std::uint32_t percent, const std::string& path) {
+                if (installerWindow) installerWindow->updateProgress(percent, path,
+                    path == "Finishing installation..." ? "Finishing" : "Extracting");
+            };
+            if (!installAssets(image, dataRoot, failure, progress)) {
+                if (reportError(failure)) continue;
+                return 1;
+            }
+            installedAssetsNow = true;
+
+            // Which language to play in. Only the European disc carries more than
+            // one, and all of them are installed either way -- about 6 MB each out
+            // of 648 MB, so leaving some out saves nothing and would mean
+            // reinstalling to change your mind.
+            pikmin::launcher::DiscIdentity identity;
+            std::string ignored;
+            const pikmin::launcher::KnownDisc* disc
+                = pikmin::launcher::inspectGameCubeImage(image, identity, ignored)
+                      ? pikmin::launcher::findKnownDisc(identity)
+                      : nullptr;
+            if (disc != nullptr && disc->languageCount > 1) {
+                std::vector<std::string> names;
+                for (int i = 0; i < disc->languageCount; ++i) {
+                    const LanguageChoice* choice = languageChoice(disc->languages[i]);
+                    names.push_back(choice ? choice->name : disc->languages[i]);
+                }
+
+                int selected = -1;
+                if (stdinIsTerminal()) {
+                    std::cout << "\nThis disc carries " << disc->languageCount << " languages:\n";
+                    for (std::size_t i = 0; i < names.size(); ++i) {
+                        std::cout << "  " << (i + 1) << ") " << names[i] << '\n';
+                    }
+                    const std::string answer = promptLine("Which one do you want to play in? [1]: ");
+                    const int number = answer.empty() ? 1 : std::atoi(answer.c_str());
+                    if (number >= 1 && number <= disc->languageCount) selected = number - 1;
+                } else {
+                    selected = askForLanguage(names);
+                }
+
+                // No way to ask, or nothing chosen: English, and say where to
+                // change it rather than leaving it a mystery.
+                const int language = (selected >= 0) ? selected : 0;
+                if (writeSettingKey(dataRoot, "language", disc->languages[language])) {
+                    std::cout << "Language: " << names[language]
+                              << "  (change it in pikmin_settings.conf, key 'language')\n";
+                }
+            }
         }
 
         std::string failure;
-        const auto progress = [&installerWindow](std::uint32_t percent, const std::string& path) {
-            if (installerWindow) installerWindow->updateProgress(percent, path);
-        };
-        if (!installAssets(image, dataRoot, failure, progress)) {
-            reportError(failure);
+        if (installerWindow) installerWindow->updateProgress(100, "Installing the launcher and game", "Finishing");
+        if (!installExecutables(sourceDirectory, dataRoot, failure)) {
+            if (reportError(failure)) continue;
             return 1;
         }
-        installedAssetsNow = true;
-
-        // Which language to play in. Only the European disc carries more than
-        // one, and all of them are installed either way -- about 6 MB each out
-        // of 648 MB, so leaving some out saves nothing and would mean
-        // reinstalling to change your mind.
-        pikmin::launcher::DiscIdentity identity;
-        std::string ignored;
-        const pikmin::launcher::KnownDisc* disc
-            = pikmin::launcher::inspectGameCubeImage(image, identity, ignored)
-                  ? pikmin::launcher::findKnownDisc(identity)
-                  : nullptr;
-        if (disc != nullptr && disc->languageCount > 1) {
-            std::vector<std::string> names;
-            for (int i = 0; i < disc->languageCount; ++i) {
-                const LanguageChoice* choice = languageChoice(disc->languages[i]);
-                names.push_back(choice ? choice->name : disc->languages[i]);
-            }
-
-            int selected = -1;
-            if (stdinIsTerminal()) {
-                std::cout << "\nThis disc carries " << disc->languageCount << " languages:\n";
-                for (std::size_t i = 0; i < names.size(); ++i) {
-                    std::cout << "  " << (i + 1) << ") " << names[i] << '\n';
-                }
-                const std::string answer = promptLine("Which one do you want to play in? [1]: ");
-                const int number = answer.empty() ? 1 : std::atoi(answer.c_str());
-                if (number >= 1 && number <= disc->languageCount) selected = number - 1;
-            } else {
-                selected = askForLanguage(names);
-            }
-
-            // No way to ask, or nothing chosen: English, and say where to
-            // change it rather than leaving it a mystery.
-            const int language = (selected >= 0) ? selected : 0;
-            if (writeSettingKey(dataRoot, "language", disc->languages[language])) {
-                std::cout << "Language: " << names[language]
-                          << "  (change it in pikmin_settings.conf, key 'language')\n";
-            }
+        if (installedAssetsNow) {
+            if (installerWindow) installerWindow->showComplete(dataRoot.string(), !extractOnly);
+            else std::cout << "Installed in: " << dataRoot << '\n'
+                           << (extractOnly ? "" : "The game will start now.\n");
         }
-    }
+        if (extractOnly) return 0;
 
-    std::string failure;
-    if (!installExecutables(sourceDirectory, dataRoot, failure)) {
-        reportError(failure);
-        return 1;
+        const fs::path gameBinary = dataRoot / kGameExecutable;
+        if (!fs::is_regular_file(gameBinary)) {
+            std::cerr << "The game executable is not next to the launcher: " << gameBinary << '\n';
+            return 1;
+        }
+        installerWindow.reset();
+        launchGame(dataRoot, gameBinary);
     }
-    if (installedAssetsNow) {
-        if (installerWindow) installerWindow->showComplete(dataRoot.string(), !extractOnly);
-        else std::cout << "Installed in: " << dataRoot << '\n'
-                       << (extractOnly ? "" : "The game will start now.\n");
-    }
-    if (extractOnly) return 0;
-
-    const fs::path gameBinary = dataRoot / kGameExecutable;
-    if (!fs::is_regular_file(gameBinary)) {
-        std::cerr << "The game executable is not next to the launcher: " << gameBinary << '\n';
-        return 1;
-    }
-    installerWindow.reset();
-    launchGame(dataRoot, gameBinary);
 }

--- a/pc_port/launcher/launcher_platform.h
+++ b/pc_port/launcher/launcher_platform.h
@@ -14,6 +14,7 @@
 // caracteres no ASCII sobreviven en ambos sistemas.
 
 #include <filesystem>
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -55,6 +56,15 @@ unsigned long currentProcessId();
 
 // Diálogo de selección de la imagen ISO/GCM. Ruta vacía si se cancela.
 std::filesystem::path askForImage();
+
+// Optional Dolphin converter, found beside the launcher or on PATH. The picker
+// lets graphical installs use an existing Dolphin download without commands.
+std::filesystem::path findConverter();
+std::filesystem::path askForConverter();
+bool convertImage(const std::filesystem::path& converter,
+                  const std::filesystem::path& source,
+                  const std::filesystem::path& destination,
+                  const std::function<void()>& pump, std::string& error);
 
 // Diálogo de selección de la carpeta de instalación. Vacía si se cancela.
 std::filesystem::path askForInstallDirectory();

--- a/pc_port/launcher/launcher_platform_posix.cpp
+++ b/pc_port/launcher/launcher_platform_posix.cpp
@@ -5,6 +5,7 @@
 #include "launcher_platform.h"
 
 #include <cstdlib>
+#include <cerrno>
 #include <cstring>
 #include <fcntl.h>
 #include <iostream>
@@ -158,14 +159,14 @@ fs::path askForImage()
     if (commandExists("zenity")) {
         const std::string selected = runDialog("zenity", {
             "--file-selection", "--title=Open Nectar - Choose your disc image",
-            "--file-filter=GameCube ISO/GCM | *.iso *.ISO *.gcm *.GCM",
+            "--file-filter=GameCube disc image | *.iso *.ISO *.gcm *.GCM *.rvz *.RVZ *.wia *.WIA *.gcz *.GCZ",
             "--file-filter=All files | *"
         });
         if (!selected.empty()) return selected;
     }
     else if (commandExists("kdialog")) {
         const std::string selected = runDialog("kdialog", {
-            "--getopenfilename", ".", "*.iso *.ISO *.gcm *.GCM|GameCube ISO/GCM"
+            "--getopenfilename", ".", "*.iso *.ISO *.gcm *.GCM *.rvz *.RVZ *.wia *.WIA *.gcz *.GCZ|GameCube disc image"
         });
         if (!selected.empty()) return selected;
     }
@@ -202,6 +203,62 @@ int askForLanguage(const std::vector<std::string>& names)
     }
 
     return -1;
+}
+
+fs::path findConverter()
+{
+    const auto beside = executablePath().parent_path() / "dolphin-tool";
+    if (fs::is_regular_file(beside) && access(beside.c_str(), X_OK) == 0) return beside;
+    const char* value = std::getenv("PATH");
+    if (!value) return {};
+    const std::string paths(value);
+    std::size_t start = 0;
+    while (start <= paths.size()) {
+        const auto end = paths.find(':', start);
+        const auto candidate = fs::path(paths.substr(start, end - start)) / "dolphin-tool";
+        if (fs::is_regular_file(candidate) && access(candidate.c_str(), X_OK) == 0)
+            return fs::absolute(candidate);
+        if (end == std::string::npos) break;
+        start = end + 1;
+    }
+    return {};
+}
+
+fs::path askForConverter()
+{
+    if (commandExists("zenity"))
+        return runDialog("zenity", { "--file-selection", "--title=Choose dolphin-tool from your Dolphin installation" });
+    if (commandExists("kdialog"))
+        return runDialog("kdialog", { "--getopenfilename", ".", "dolphin-tool", "--title", "Choose dolphin-tool" });
+    return {};
+}
+
+bool convertImage(const fs::path& converter, const fs::path& source,
+                  const fs::path& destination, const std::function<void()>& pump, std::string& error)
+{
+    const pid_t child = fork();
+    if (child == 0) {
+        execl(converter.c_str(), converter.c_str(), "convert", "-i", source.c_str(),
+              "-o", destination.c_str(), "-f", "iso", static_cast<char*>(nullptr));
+        _exit(127);
+    }
+    if (child < 0) { error = "Could not start dolphin-tool: " + std::string(std::strerror(errno)); return false; }
+    int status = 0;
+    for (;;) {
+        const pid_t result = waitpid(child, &status, WNOHANG);
+        if (result == child) break;
+        if (result < 0) {
+            if (errno == EINTR) continue;
+            error = "Could not wait for dolphin-tool: " + std::string(std::strerror(errno));
+            return false;
+        }
+        if (pump) pump();
+        usleep(50000);
+    }
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) return true;
+    error = "Disc conversion failed. Check that dolphin-tool runs, the temporary folder has free space, "
+            "and the disc image opens in Dolphin.";
+    return false;
 }
 
 // When the launcher is started by double-clicking it in a file manager there

--- a/pc_port/launcher/launcher_platform_win32.cpp
+++ b/pc_port/launcher/launcher_platform_win32.cpp
@@ -125,7 +125,7 @@ fs::path askForImage()
     OPENFILENAMEW dialog {};
     dialog.lStructSize = sizeof(dialog);
     dialog.hwndOwner   = nullptr;
-    dialog.lpstrFilter = L"GameCube ISO/GCM\0*.iso;*.gcm\0All files\0*.*\0\0";
+    dialog.lpstrFilter = L"GameCube disc image\0*.iso;*.gcm;*.rvz;*.wia;*.gcz\0All files\0*.*\0\0";
     dialog.lpstrFile   = selected.data();
     dialog.nMaxFile    = static_cast<DWORD>(selected.size());
     dialog.lpstrTitle  = L"Open Nectar - Choose your disc image";
@@ -183,6 +183,75 @@ int askForLanguage(const std::vector<std::string>& names)
     // graphical one falls back to the default and says where to change it.
     (void)names;
     return -1;
+}
+
+fs::path findConverter()
+{
+    for (const wchar_t* name : { L"DolphinTool.exe", L"dolphin-tool.exe" }) {
+        const auto beside = executablePath().parent_path() / name;
+        if (fs::is_regular_file(beside)) return beside;
+    }
+    const wchar_t* value = _wgetenv(L"PATH");
+    if (!value) return {};
+    const std::wstring paths(value);
+    std::size_t start = 0;
+    while (start <= paths.size()) {
+        const auto end = paths.find(L';', start);
+        auto directory = paths.substr(start, end - start);
+        if (directory.size() >= 2 && directory.front() == L'"' && directory.back() == L'"')
+            directory = directory.substr(1, directory.size() - 2);
+        if (!directory.empty()) {
+            for (const wchar_t* name : { L"DolphinTool.exe", L"dolphin-tool.exe" }) {
+                const auto candidate = fs::path(directory) / name;
+                if (fs::is_regular_file(candidate)) return fs::absolute(candidate);
+            }
+        }
+        if (end == std::wstring::npos) break;
+        start = end + 1;
+    }
+    return {};
+}
+
+fs::path askForConverter()
+{
+    std::vector<wchar_t> selected(32768);
+    OPENFILENAMEW dialog {};
+    dialog.lStructSize = sizeof(dialog);
+    dialog.lpstrFilter = L"Dolphin converter\0DolphinTool.exe;dolphin-tool.exe\0\0";
+    dialog.lpstrFile = selected.data();
+    dialog.nMaxFile = static_cast<DWORD>(selected.size());
+    dialog.lpstrTitle = L"Choose DolphinTool.exe from your Dolphin installation";
+    dialog.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR | OFN_EXPLORER;
+    return GetOpenFileNameW(&dialog) ? fs::path(selected.data()) : fs::path();
+}
+
+bool convertImage(const fs::path& converter, const fs::path& source,
+                  const fs::path& destination, const std::function<void()>& pump, std::string& error)
+{
+    // All arguments are file paths (no trailing directory separator); Windows
+    // filenames cannot contain quotes. No shell interprets the command line.
+    std::wstring command = L"\"" + converter.wstring() + L"\" convert -i \""
+                         + source.wstring() + L"\" -o \"" + destination.wstring() + L"\" -f iso";
+    STARTUPINFOW startup {};
+    startup.cb = sizeof(startup);
+    PROCESS_INFORMATION process {};
+    if (!CreateProcessW(converter.c_str(), command.data(), nullptr, nullptr, FALSE,
+                        CREATE_NO_WINDOW, nullptr, nullptr, &startup, &process)) {
+        error = "Could not start dolphin-tool (Windows error " + std::to_string(GetLastError())
+              + "). Select DolphinTool.exe from a complete Dolphin installation.";
+        return false;
+    }
+    CloseHandle(process.hThread);
+    while (WaitForSingleObject(process.hProcess, 50) == WAIT_TIMEOUT) {
+        if (pump) pump();
+    }
+    DWORD code = 1;
+    GetExitCodeProcess(process.hProcess, &code);
+    CloseHandle(process.hProcess);
+    if (code == 0) return true;
+    error = "Disc conversion failed (dolphin-tool exit " + std::to_string(code)
+          + "). Check free space in the temporary folder and try your disc image in Dolphin.";
+    return false;
 }
 
 bool respawnInTerminal()

--- a/pc_port/launcher/prepared_image.h
+++ b/pc_port/launcher/prepared_image.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <functional>
+#include <random>
+#include <string>
+
+namespace pikmin::launcher {
+
+inline bool isCompressedImage(const std::filesystem::path& image)
+{
+    std::string ext = image.extension().string();
+    std::transform(ext.begin(), ext.end(), ext.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return ext == ".rvz" || ext == ".wia" || ext == ".gcz";
+}
+
+// Own only a newly created temporary directory, never the source image or a
+// previous conversion. Scope this object before launchGame (which exits).
+class PreparedImage {
+public:
+    PreparedImage() = default;
+    PreparedImage(const PreparedImage&) = delete;
+    PreparedImage& operator=(const PreparedImage&) = delete;
+    ~PreparedImage() { clear(); }
+
+    using Convert = std::function<bool(const std::filesystem::path&,
+                                      const std::filesystem::path&, std::string&)>;
+
+    bool prepare(const std::filesystem::path& source, const Convert& convert, std::string& error)
+    {
+        clear();
+        image = source;
+        if (!isCompressedImage(source)) return true;
+        std::error_code ec;
+        const auto root = std::filesystem::temp_directory_path(ec);
+        if (ec) { error = "Could not find the temporary folder: " + ec.message(); return false; }
+        std::random_device random;
+        for (int attempt = 0; attempt < 16; ++attempt) {
+            const auto candidate = root / ("nectar-disc-" + std::to_string(random())
+                                          + "-" + std::to_string(random()));
+            if (std::filesystem::create_directory(candidate, ec)) {
+                temporary = candidate;
+                break;
+            }
+            if (ec && ec != std::errc::file_exists) {
+                error = "Could not create a temporary conversion folder: " + ec.message();
+                return false;
+            }
+        }
+        if (temporary.empty()) { error = "Could not reserve a temporary conversion folder."; return false; }
+        image = temporary / "disc.iso";
+        if (!convert(source, image, error)) { clear(); return false; }
+        if (!std::filesystem::is_regular_file(image, ec) || std::filesystem::file_size(image, ec) == 0 || ec) {
+            error = "The converter did not produce an ISO. Check free space and your disc image.";
+            clear();
+            return false;
+        }
+        return true;
+    }
+
+    std::filesystem::path image;
+
+private:
+    std::filesystem::path temporary;
+    void clear()
+    {
+        if (!temporary.empty()) {
+            std::error_code ec;
+            std::filesystem::remove_all(temporary, ec);
+            temporary.clear();
+        }
+    }
+};
+} // namespace pikmin::launcher

--- a/pc_port/launcher/prepared_image_test.cpp
+++ b/pc_port/launcher/prepared_image_test.cpp
@@ -1,0 +1,69 @@
+#include "prepared_image.h"
+#include "launcher_platform.h"
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+
+namespace fs = std::filesystem;
+void check(bool value, const char* message)
+{
+    if (!value) { std::cerr << message << '\n'; std::exit(1); }
+}
+
+int main(int argc, char** argv)
+{
+    // Run this executable as a synthetic converter to exercise argument passing
+    // and child-process waiting without Dolphin or any retail game data.
+    if (argc > 1 && std::string(argv[1]) == "convert") {
+        if (argc != 8 || std::string(argv[2]) != "-i" || std::string(argv[4]) != "-o"
+            || std::string(argv[6]) != "-f" || std::string(argv[7]) != "iso") return 2;
+        std::ifstream source(argv[3]);
+        std::string contents;
+        std::getline(source, contents);
+        std::ofstream(argv[5]) << contents;
+        return contents == "success" ? 0 : 9;
+    }
+    using namespace pikmin::launcher;
+    const auto root = fs::temp_directory_path() / ("nectar conversion test " + std::to_string(std::random_device{}()));
+    check(fs::create_directory(root), "reserve test directory");
+    const auto source = root / "disc & spaced.RVZ";
+    std::ofstream(source) << "success";
+    std::string error;
+    fs::path temporary;
+    int pumps = 0;
+    const auto converter = fs::absolute(argv[0]);
+    const auto run = [&](const fs::path& input, const fs::path& output, std::string& failure) {
+        temporary = output.parent_path();
+        return platform::convertImage(converter, input, output, [&] { ++pumps; }, failure);
+    };
+    {
+        PreparedImage prepared;
+        check(prepared.prepare(source, run, error), error.c_str());
+        check(prepared.image != source && fs::file_size(prepared.image) == 7, "converted output");
+        check(fs::exists(source), "source preserved");
+    }
+    check(!fs::exists(temporary), "successful conversion cleaned up");
+    std::ofstream(source) << "failure";
+    {
+        PreparedImage prepared;
+        check(!prepared.prepare(source, run, error), "nonzero child exit rejected");
+        check(!fs::exists(temporary), "failed conversion cleaned up");
+        check(fs::file_size(source) == 7, "failed conversion preserves source");
+        check(!prepared.prepare(source, [&](const fs::path&, const fs::path& output, std::string&) {
+            temporary = output.parent_path();
+            return true;
+        }, error), "success without output rejected");
+        check(!fs::exists(temporary), "missing output cleaned up");
+        const auto iso = root / "original.iso";
+        std::ofstream(iso) << "original";
+        check(prepared.prepare(iso, [](const fs::path&, const fs::path&, std::string&) {
+            check(false, "uncompressed images must bypass converter"); return false;
+        }, error), "ISO bypass");
+        check(prepared.image == iso, "ISO path unchanged");
+    }
+    check(fs::exists(root / "original.iso"), "original ISO preserved after destructor");
+    fs::remove(root / "original.iso");
+    fs::remove(source);
+    fs::remove(root);
+    std::cout << "PASS conversion process, failure propagation, temporary cleanup and ISO bypass\n";
+}


### PR DESCRIPTION
The first-run launcher rejects compressed disc images, labels verification as extraction, and exits after a failed install. This lets players select RVZ/WIA/GCZ directly and return to setup to correct a failed attempt, while keeping the existing ISO/GCM path.

- Use an existing Dolphin converter, discovered beside the launcher/on PATH or selected with a file picker. Windows recognizes DolphinTool.exe and dolphin-tool.exe; --dolphin-tool supports headless installs. No converter download, new bundled dependency, or game data is included.
- Convert into a uniquely reserved temporary directory, verify the resulting ISO with the existing checks, and clean it up when the attempt ends. Never reuse interrupted output or modify the source image.
- Distinguish conversion, verification, extraction and finalization; keep original selections when returning to setup. Retry transient finalization locks at most five times over 2.5 seconds and preserve extraction on persistent failure.
- Show F1 settings guidance before installation and at completion, and document temporary-space requirements and recovery.

Validation:
- Windows Release launcher build passed with MinGW.
- Five targeted CTests passed: gamecube_image_test, sha256_test, installer_ui_test, asset_finalize_test, prepared_image_test. These include a real Windows directory lock, synthetic converter process/exit handling with spaced paths, temporary cleanup, ISO bypass, and selection retention across setup attempts.
- Fresh Windows ISO and RVZ installs completed with disc verification and --extract-only; the RVZ run used an existing DolphinTool.exe and left no conversion directory.
- Initial installer screen and F1 hint visually checked. Full graphical install/recovery flow and Linux execution have not been verified locally; the two fresh-install checks used CLI entry points.

This changes the standalone launcher only; it adds no randomizer/AP dependency or gameplay changes.
